### PR TITLE
fix: use explicit --oracle flag instead of indexFeedId in withdraw, c…

### DIFF
--- a/src/commands/close-account.ts
+++ b/src/commands/close-account.ts
@@ -20,6 +20,7 @@ export function registerCloseAccount(program: Command): void {
     .description("Close a user account and withdraw remaining collateral")
     .requiredOption("--slab <pubkey>", "Slab account public key")
     .requiredOption("--user-idx <number>", "User account index to close")
+    .requiredOption("--oracle <pubkey>", "Price oracle account")
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
@@ -27,6 +28,7 @@ export function registerCloseAccount(program: Command): void {
 
       // Validate inputs
       const slabPk = validatePublicKey(opts.slab, "--slab");
+      const oracle = validatePublicKey(opts.oracle, "--oracle");
       const userIdx = validateIndex(opts.userIdx, "--user-idx");
 
       // Fetch slab config for vault and oracle
@@ -51,7 +53,7 @@ export function registerCloseAccount(program: Command): void {
         vaultPda, // vaultPda
         WELL_KNOWN.tokenProgram, // tokenProgram
         WELL_KNOWN.clock, // clock
-        mktConfig.indexFeedId, // oracle
+        oracle, // oracle
       ]);
 
       const ix = buildIx({

--- a/src/commands/trade-cpi.ts
+++ b/src/commands/trade-cpi.ts
@@ -3,7 +3,7 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
 import { createContext } from "../runtime/context.js";
-import { fetchSlab, parseConfig, parseAccount } from "../solana/slab.js";
+import { fetchSlab, parseAccount } from "../solana/slab.js";
 import { deriveLpPda } from "../solana/pda.js";
 import { encodeTradeCpi } from "../abi/instructions.js";
 import {
@@ -28,6 +28,7 @@ export function registerTradeCpi(program: Command): void {
     .requiredOption("--size <string>", "Trade size (i128, positive=long, negative=short)")
     .requiredOption("--matcher-program <pubkey>", "Matcher program ID")
     .requiredOption("--matcher-context <pubkey>", "Matcher context account")
+    .requiredOption("--oracle <pubkey>", "Price oracle account")
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
@@ -35,15 +36,14 @@ export function registerTradeCpi(program: Command): void {
 
       // Validate inputs
       const slabPk = validatePublicKey(opts.slab, "--slab");
+      const oracle = validatePublicKey(opts.oracle, "--oracle");
       const matcherProgram = validatePublicKey(opts.matcherProgram, "--matcher-program");
       const matcherContext = validatePublicKey(opts.matcherContext, "--matcher-context");
       const lpIdx = validateIndex(opts.lpIdx, "--lp-idx");
       const userIdx = validateIndex(opts.userIdx, "--user-idx");
       validateI128(opts.size, "--size");
 
-      // Fetch slab config for oracle
       const data = await fetchSlab(ctx.connection, slabPk);
-      const mktConfig = parseConfig(data);
 
       // Derive LP PDA
       const [lpPda] = deriveLpPda(ctx.programId, slabPk, lpIdx);
@@ -65,7 +65,7 @@ export function registerTradeCpi(program: Command): void {
         lpOwnerPk, // lpOwner (read from slab, not a signer)
         slabPk, // slab
         WELL_KNOWN.clock, // clock
-        mktConfig.indexFeedId, // oracle (use index feed ID from config)
+        oracle, // oracle
         matcherProgram, // matcherProg
         matcherContext, // matcherCtx
         lpPda, // lpPda

--- a/src/commands/withdraw.ts
+++ b/src/commands/withdraw.ts
@@ -25,6 +25,7 @@ export function registerWithdraw(program: Command): void {
     .requiredOption("--slab <pubkey>", "Slab account public key")
     .requiredOption("--user-idx <number>", "User account index")
     .requiredOption("--amount <string>", "Amount to withdraw (native units)")
+    .requiredOption("--oracle <pubkey>", "Price oracle account")
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
@@ -32,6 +33,7 @@ export function registerWithdraw(program: Command): void {
 
       // Validate inputs
       const slabPk = validatePublicKey(opts.slab, "--slab");
+      const oracle = validatePublicKey(opts.oracle, "--oracle");
       const userIdx = validateIndex(opts.userIdx, "--user-idx");
       validateAmount(opts.amount, "--amount");
       const amount = opts.amount;
@@ -58,7 +60,7 @@ export function registerWithdraw(program: Command): void {
         vaultPda, // vaultPda
         WELL_KNOWN.tokenProgram, // tokenProgram
         WELL_KNOWN.clock, // clock
-        mktConfig.indexFeedId, // oracle
+        oracle, // oracle
       ]);
 
       const ix = buildIx({


### PR DESCRIPTION
Problem
withdraw, close-account, and trade-cpi read indexFeedId from the slab config and pass it directly as the oracle account in the transaction's account list.

This works on Chainlink markets by coincidence — Chainlink's indexFeedId happens to be the oracle account pubkey. On Pyth markets, indexFeedId is a 32-byte feed ID hash, not a valid Solana account. The transaction fails with a confusing runtime error.

Six other commands (keeper-crank, trade-nocpi, liquidate-at-oracle, best-price, push-oracle-price, set-oracle-authority) already take --oracle as an explicit flag and don't have this bug. The inconsistency means only these three commands are broken.

No funds at risk — the on-chain program rejects the malformed account — but the CLI is non-functional for withdraw, close-account, and CPI trading on any Pyth-based market.

Fix
Add --oracle <pubkey> as a required flag to all three commands. Remove the implicit indexFeedId usage.

Changes
src/commands/withdraw.ts — add --oracle, replace mktConfig.indexFeedId
src/commands/close-account.ts — same
src/commands/trade-cpi.ts — same, drop unused parseConfig import
3 files changed, 10 insertions(+), 6 deletions(-). Nothing else touched.