### PR TITLE
Security: verify slab account ownership to prevent spoofed account attacks

### DIFF
--- a/src/commands/best-price.ts
+++ b/src/commands/best-price.ts
@@ -119,7 +119,7 @@ export function registerBestPrice(program: Command): void {
 
       // Fetch slab and oracle in parallel
       const [slabData, oracleData] = await Promise.all([
-        fetchSlab(ctx.connection, slabPk),
+        fetchSlab(ctx.connection, slabPk, ctx.programId),
         getChainlinkPrice(ctx.connection, oraclePk),
       ]);
 

--- a/src/commands/close-account.ts
+++ b/src/commands/close-account.ts
@@ -30,7 +30,7 @@ export function registerCloseAccount(program: Command): void {
       const userIdx = validateIndex(opts.userIdx, "--user-idx");
 
       // Fetch slab config for vault and oracle
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Get user's ATA for the collateral mint

--- a/src/commands/close-slab.ts
+++ b/src/commands/close-slab.ts
@@ -28,7 +28,7 @@ export function registerCloseSlab(program: Command): void {
       const slabPk = validatePublicKey(opts.slab, "--slab");
 
       // Fetch slab config for vault, mint
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Derive vault authority PDA

--- a/src/commands/deposit.ts
+++ b/src/commands/deposit.ts
@@ -36,7 +36,7 @@ export function registerDeposit(program: Command): void {
       const amount = opts.amount;
 
       // Fetch slab config for vault
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Get user's ATA for the collateral mint

--- a/src/commands/init-lp.ts
+++ b/src/commands/init-lp.ts
@@ -33,7 +33,7 @@ export function registerInitLp(program: Command): void {
       validateU128(opts.fee, "--fee");
 
       // Fetch slab config for mint, vault, oracle
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Get user's ATA for the collateral mint

--- a/src/commands/init-user.ts
+++ b/src/commands/init-user.ts
@@ -29,7 +29,7 @@ export function registerInitUser(program: Command): void {
       validateU128(opts.fee, "--fee");
 
       // Fetch slab config for mint, vault, oracle
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Get user's ATA for the collateral mint

--- a/src/commands/keeper-crank.ts
+++ b/src/commands/keeper-crank.ts
@@ -112,7 +112,7 @@ export function registerKeeperCrank(program: Command): void {
       const allowPanic = opts.allowPanic === true;
 
       // Fetch slab data and compute liquidation candidates off-chain
-      const slabData = await fetchSlab(ctx.connection, slabPk);
+      const slabData = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const engine = parseEngine(slabData);
       const candidates = computeCandidates(slabData, engine);
 

--- a/src/commands/slab-account.ts
+++ b/src/commands/slab-account.ts
@@ -18,7 +18,7 @@ export function registerSlabAccount(program: Command): void {
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const idx = validateIndex(opts.idx, "--idx");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
 
       if (!isAccountUsed(data, idx)) {
         if (flags.json) {

--- a/src/commands/slab-accounts.ts
+++ b/src/commands/slab-accounts.ts
@@ -16,7 +16,7 @@ export function registerSlabAccounts(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const accounts = parseAllAccounts(data);
 
       if (flags.json) {

--- a/src/commands/slab-bitmap.ts
+++ b/src/commands/slab-bitmap.ts
@@ -16,7 +16,7 @@ export function registerSlabBitmap(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const indices = parseUsedIndices(data);
       const engine = parseEngine(data);
 

--- a/src/commands/slab-config.ts
+++ b/src/commands/slab-config.ts
@@ -16,7 +16,7 @@ export function registerSlabConfig(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const header = parseHeader(data);
       const mktConfig = parseConfig(data);
 

--- a/src/commands/slab-engine.ts
+++ b/src/commands/slab-engine.ts
@@ -16,7 +16,7 @@ export function registerSlabEngine(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const engine = parseEngine(data);
 
       if (flags.json) {

--- a/src/commands/slab-get.ts
+++ b/src/commands/slab-get.ts
@@ -16,7 +16,7 @@ export function registerSlabGet(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const header = parseHeader(data);
       const mktConfig = parseConfig(data);
 

--- a/src/commands/slab-header.ts
+++ b/src/commands/slab-header.ts
@@ -16,7 +16,7 @@ export function registerSlabHeader(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const header = parseHeader(data);
 
       if (flags.json) {

--- a/src/commands/slab-nonce.ts
+++ b/src/commands/slab-nonce.ts
@@ -16,7 +16,7 @@ export function registerSlabNonce(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const nonce = readNonce(data);
 
       if (flags.json) {

--- a/src/commands/slab-params.ts
+++ b/src/commands/slab-params.ts
@@ -16,7 +16,7 @@ export function registerSlabParams(program: Command): void {
       const ctx = createContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const params = parseParams(data);
 
       if (flags.json) {

--- a/src/commands/topup-insurance.ts
+++ b/src/commands/topup-insurance.ts
@@ -29,7 +29,7 @@ export function registerTopupInsurance(program: Command): void {
       validateU128(opts.amount, "--amount");
 
       // Fetch slab config for vault
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Get user's ATA for the collateral mint

--- a/src/commands/trade-cpi.ts
+++ b/src/commands/trade-cpi.ts
@@ -42,7 +42,7 @@ export function registerTradeCpi(program: Command): void {
       validateI128(opts.size, "--size");
 
       // Fetch slab config for oracle
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Derive LP PDA

--- a/src/commands/withdraw-insurance.ts
+++ b/src/commands/withdraw-insurance.ts
@@ -24,7 +24,7 @@ export function registerWithdrawInsurance(program: Command): void {
       const slabPk = validatePublicKey(opts.slab, "--slab");
 
       // Fetch slab config to get vault and mint
-      const slabData = await fetchSlab(ctx.connection, slabPk);
+      const slabData = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const slabConfig = parseConfig(slabData);
 
       const [vaultPda] = deriveVaultAuthority(ctx.programId, slabPk);

--- a/src/commands/withdraw.ts
+++ b/src/commands/withdraw.ts
@@ -37,7 +37,7 @@ export function registerWithdraw(program: Command): void {
       const amount = opts.amount;
 
       // Fetch slab config for vault and oracles
-      const data = await fetchSlab(ctx.connection, slabPk);
+      const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);
       const mktConfig = parseConfig(data);
 
       // Get user's ATA for the collateral mint

--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -102,14 +102,23 @@ export interface MarketConfig {
 
 /**
  * Fetch raw slab account data.
+ * When expectedOwner is provided, verifies the account is owned by the expected program
+ * to prevent spoofed slab accounts from redirecting funds.
  */
 export async function fetchSlab(
   connection: Connection,
-  slabPubkey: PublicKey
+  slabPubkey: PublicKey,
+  expectedOwner?: PublicKey
 ): Promise<Buffer> {
   const info = await connection.getAccountInfo(slabPubkey);
   if (!info) {
     throw new Error(`Slab account not found: ${slabPubkey.toBase58()}`);
+  }
+  if (expectedOwner && !info.owner.equals(expectedOwner)) {
+    throw new Error(
+      `Slab account ${slabPubkey.toBase58()} is owned by ${info.owner.toBase58()}, ` +
+      `expected ${expectedOwner.toBase58()}. This may indicate a spoofed account.`
+    );
   }
   return Buffer.from(info.data);
 }


### PR DESCRIPTION
## Summary
- `fetchSlab()` now verifies `info.owner` matches the expected `programId` before returning account data
- All 20 command callers in `src/commands/` pass `ctx.programId` for verification
- Parameter is optional to maintain backwards compatibility with scripts

## Problem
`fetchSlab()` trusted any account data without checking ownership. An attacker could create a spoofed account with matching PERCOLAT magic bytes but attacker-controlled `vaultPubkey` / `collateralMint` fields. Commands like `deposit` would then send user tokens to the attacker's vault.

**Attack vector:** User is phished into providing a `--slab` address pointing to a fake account, or a rogue RPC server returns crafted account data.

## Test plan
- [x] `tsup` build succeeds
- [x] All 46 existing tests pass (`npm test`)
- [x] CLI runs correctly (`node dist/index.js --help`)
- [ ] Manual test: passing a non-program-owned account as `--slab` should produce a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)