### PR TITLE
Security: add client-side slippage protection to trade commands

### DIFF
--- a/src/commands/trade-cpi.ts
+++ b/src/commands/trade-cpi.ts
@@ -16,6 +16,7 @@ import {
   validatePublicKey,
   validateIndex,
   validateI128,
+  validateAmount,
 } from "../validation.js";
 
 export function registerTradeCpi(program: Command): void {
@@ -28,6 +29,8 @@ export function registerTradeCpi(program: Command): void {
     .requiredOption("--size <string>", "Trade size (i128, positive=long, negative=short)")
     .requiredOption("--matcher-program <pubkey>", "Matcher program ID")
     .requiredOption("--matcher-context <pubkey>", "Matcher context account")
+    .option("--max-price <string>", "Max acceptable price (e6 units, client-side slippage guard)")
+    .option("--min-price <string>", "Min acceptable price (e6 units, client-side slippage guard)")
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
@@ -44,6 +47,30 @@ export function registerTradeCpi(program: Command): void {
       // Fetch slab config for oracle
       const data = await fetchSlab(ctx.connection, slabPk);
       const mktConfig = parseConfig(data);
+
+      // Client-side slippage protection: check last effective price against user bounds
+      if (opts.maxPrice || opts.minPrice) {
+        const currentPrice = mktConfig.lastEffectivePriceE6;
+
+        if (opts.maxPrice) {
+          const maxPrice = validateAmount(opts.maxPrice, "--max-price");
+          if (currentPrice > maxPrice) {
+            throw new Error(
+              `Current price ${currentPrice} exceeds --max-price ${maxPrice}. ` +
+              `Trade aborted (client-side slippage guard).`
+            );
+          }
+        }
+        if (opts.minPrice) {
+          const minPrice = validateAmount(opts.minPrice, "--min-price");
+          if (currentPrice < minPrice) {
+            throw new Error(
+              `Current price ${currentPrice} is below --min-price ${minPrice}. ` +
+              `Trade aborted (client-side slippage guard).`
+            );
+          }
+        }
+      }
 
       // Derive LP PDA
       const [lpPda] = deriveLpPda(ctx.programId, slabPk, lpIdx);

--- a/src/commands/trade-nocpi.ts
+++ b/src/commands/trade-nocpi.ts
@@ -4,6 +4,7 @@ import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
 import { createContext } from "../runtime/context.js";
 import { loadKeypair } from "../solana/wallet.js";
+import { fetchSlab, parseConfig } from "../solana/slab.js";
 import { encodeTradeNoCpi } from "../abi/instructions.js";
 import {
   ACCOUNTS_TRADE_NOCPI,
@@ -15,6 +16,7 @@ import {
   validatePublicKey,
   validateIndex,
   validateI128,
+  validateAmount,
 } from "../validation.js";
 
 export function registerTradeNocpi(program: Command): void {
@@ -27,6 +29,8 @@ export function registerTradeNocpi(program: Command): void {
     .requiredOption("--size <string>", "Trade size (i128, positive=long, negative=short)")
     .requiredOption("--oracle <pubkey>", "Price oracle account")
     .option("--lp-wallet <path>", "LP wallet keypair (if different from payer)")
+    .option("--max-price <string>", "Max acceptable price (e6 units, client-side slippage guard)")
+    .option("--min-price <string>", "Min acceptable price (e6 units, client-side slippage guard)")
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
@@ -38,6 +42,32 @@ export function registerTradeNocpi(program: Command): void {
       const lpIdx = validateIndex(opts.lpIdx, "--lp-idx");
       const userIdx = validateIndex(opts.userIdx, "--user-idx");
       validateI128(opts.size, "--size");
+
+      // Client-side slippage protection: check last effective price against user bounds
+      if (opts.maxPrice || opts.minPrice) {
+        const data = await fetchSlab(ctx.connection, slabPk);
+        const mktConfig = parseConfig(data);
+        const currentPrice = mktConfig.lastEffectivePriceE6;
+
+        if (opts.maxPrice) {
+          const maxPrice = validateAmount(opts.maxPrice, "--max-price");
+          if (currentPrice > maxPrice) {
+            throw new Error(
+              `Current price ${currentPrice} exceeds --max-price ${maxPrice}. ` +
+              `Trade aborted (client-side slippage guard).`
+            );
+          }
+        }
+        if (opts.minPrice) {
+          const minPrice = validateAmount(opts.minPrice, "--min-price");
+          if (currentPrice < minPrice) {
+            throw new Error(
+              `Current price ${currentPrice} is below --min-price ${minPrice}. ` +
+              `Trade aborted (client-side slippage guard).`
+            );
+          }
+        }
+      }
 
       // Load LP keypair if provided, otherwise use payer
       const lpKeypair = opts.lpWallet ? loadKeypair(opts.lpWallet) : ctx.payer;


### PR DESCRIPTION
## Summary
- `trade-nocpi` and `trade-cpi` now accept optional `--max-price` and `--min-price` flags (e6 units)
- Before sending, checks `lastEffectivePriceE6` from slab data against user-specified bounds
- Price inputs validated via `validateAmount()` for proper error messages on bad input

## Problem
Neither trade command had any price bounds. Users are exposed to:
- **Fat-finger errors**: accidentally trading at a wildly wrong price
- **Sandwich attacks**: MEV bots front-running trades to move the price
- **Stale oracle mispricing**: trading when the oracle price is significantly off

The on-chain instruction format (`TradeNoCpi`/`TradeCpi`) does not include a price limit field, so this is a client-side TOCTOU guard. It checks the last effective price from the slab before submitting the transaction.

## Usage
```bash
# Abort if price > 150_000_000 (e6 units)
percolator-cli trade-nocpi --slab ... --size 1000 --oracle ... --max-price 150000000

# Abort if price < 90_000_000
percolator-cli trade-cpi --slab ... --size -500 --matcher-program ... --matcher-context ... --min-price 90000000
```

## Test plan
- [x] `tsup` build succeeds
- [x] All 46 existing tests pass (`npm test`)
- [x] `trade-nocpi --help` and `trade-cpi --help` show new flags
- [ ] Manual test: passing `--max-price 1` should abort with clear error on any live market

🤖 Generated with [Claude Code](https://claude.com/claude-code)