### PR TITLE
Fix: return exit code 1 on transaction failure

### DIFF
--- a/src/runtime/tx.ts
+++ b/src/runtime/tx.ts
@@ -156,8 +156,14 @@ export async function simulateOrSend(
 
 /**
  * Format transaction result for output.
+ * Sets process.exitCode = 1 when the transaction failed so scripts/bots
+ * can reliably detect failures via exit code.
  */
 export function formatResult(result: TxResult, jsonMode: boolean): string {
+  if (result.err) {
+    process.exitCode = 1;
+  }
+
   if (jsonMode) {
     return JSON.stringify(result, null, 2);
   }


### PR DESCRIPTION
## Summary
- `formatResult()` now sets `process.exitCode = 1` when `result.err` is non-null
- One-line fix, zero breaking changes — all 20+ commands automatically inherit this

## Problem
When `simulateOrSend()` catches a transaction error (send failure, confirmation timeout, on-chain execution error), it returns a result object with `err` set. Every command then calls `formatResult()` which prints the error, but the process exits with code 0.

This means scripts and keeper bots that check exit codes cannot distinguish success from failure:
```bash
percolator-cli deposit --slab ... --amount 1000
echo $?  # Always 0, even if the transaction failed
```

**Impact for keeper bots:** A crank bot running `keeper-crank` in a loop sees exit code 0 on every call regardless of outcome. If the RPC is down or transactions are failing, the bot reports success. Liquidations stop processing silently, positions go underwater.

## Fix
Uses `process.exitCode = 1` (not `process.exit(1)`) so the process exits cleanly after printing output.

## Test plan
- [x] `tsup` build succeeds
- [x] All 46 existing tests pass (`npm test`)
- [x] CLI runs correctly
- [ ] Manual test: a failing transaction should produce exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)