### PR TITLE
Security: add oracle timestamp parsing and staleness warning

### DIFF
--- a/src/commands/best-price.ts
+++ b/src/commands/best-price.ts
@@ -125,6 +125,9 @@ export function registerBestPrice(program: Command): void {
 
       const oraclePrice = oracleData.price;
       const oraclePriceUsd = Number(oraclePrice) / Math.pow(10, oracleData.decimals);
+      const oracleAgeSecs = oracleData.timestamp > 0
+        ? Math.floor(Date.now() / 1000) - oracleData.timestamp
+        : -1;
 
       // Find all LPs and collect matcher context addresses
       const usedIndices = parseUsedIndices(slabData);
@@ -198,6 +201,8 @@ export function registerBestPrice(program: Command): void {
             price: oraclePrice.toString(),
             priceUsd: oraclePriceUsd,
             decimals: oracleData.decimals,
+            timestamp: oracleData.timestamp,
+            ageSecs: oracleAgeSecs >= 0 ? oracleAgeSecs : null,
           },
           lps: quotes.map(q => ({
             index: q.lpIndex,
@@ -228,6 +233,14 @@ export function registerBestPrice(program: Command): void {
       } else {
         console.log("=== Best Price Scanner ===\n");
         console.log(`Oracle: $${oraclePriceUsd.toFixed(2)}`);
+        if (oracleAgeSecs >= 0) {
+          const ageStr = oracleAgeSecs < 60
+            ? `${oracleAgeSecs}s`
+            : oracleAgeSecs < 3600
+              ? `${Math.floor(oracleAgeSecs / 60)}m ${oracleAgeSecs % 60}s`
+              : `${(oracleAgeSecs / 3600).toFixed(1)}h`;
+          console.log(`Oracle age: ${ageStr}${oracleAgeSecs > 120 ? " ⚠ STALE" : ""}`);
+        }
         console.log(`LPs found: ${quotes.length}\n`);
 
         console.log("--- LP Quotes ---");

--- a/src/solana/oracle.ts
+++ b/src/solana/oracle.ts
@@ -17,12 +17,17 @@ const MAX_DECIMALS = 18;
 /** Offset of decimals field in Chainlink aggregator account */
 const CHAINLINK_DECIMALS_OFFSET = 138;
 
+/** Offset of unix timestamp in Chainlink aggregator account */
+const CHAINLINK_TIMESTAMP_OFFSET = 208;
+
 /** Offset of latest answer in Chainlink aggregator account */
 const CHAINLINK_ANSWER_OFFSET = 216;
 
 export interface OraclePrice {
   price: bigint;
   decimals: number;
+  /** Unix timestamp of the last price update (0 if unavailable) */
+  timestamp: number;
 }
 
 /**
@@ -49,6 +54,8 @@ export function parseChainlinkPrice(data: Buffer): OraclePrice {
     );
   }
 
+  const timestamp = Number(data.readBigUInt64LE(CHAINLINK_TIMESTAMP_OFFSET));
+
   const price = data.readBigInt64LE(CHAINLINK_ANSWER_OFFSET);
   if (price <= 0n) {
     throw new Error(
@@ -56,5 +63,5 @@ export function parseChainlinkPrice(data: Buffer): OraclePrice {
     );
   }
 
-  return { price, decimals };
+  return { price, decimals, timestamp };
 }

--- a/test/oracle.test.ts
+++ b/test/oracle.test.ts
@@ -29,10 +29,11 @@ function assertThrows(fn: () => void, expectedMsg: string, testName: string): vo
 console.log("Testing oracle parsing...\n");
 
 // Helper: build a valid Chainlink aggregator buffer
-// Chainlink layout: decimals at offset 138 (u8), answer at offset 216 (i64 LE)
-function buildChainlinkBuffer(decimals: number, answer: bigint, size = 256): Buffer {
+// Chainlink layout: decimals at offset 138 (u8), timestamp at offset 208 (u64 LE), answer at offset 216 (i64 LE)
+function buildChainlinkBuffer(decimals: number, answer: bigint, size = 256, timestamp = 0n): Buffer {
   const buf = Buffer.alloc(size);
   buf.writeUInt8(decimals, 138);
+  buf.writeBigUInt64LE(timestamp, 208);
   buf.writeBigInt64LE(answer, 216);
   return buf;
 }
@@ -43,8 +44,19 @@ function buildChainlinkBuffer(decimals: number, answer: bigint, size = 256): Buf
   const result = parseChainlinkPrice(buf);
   assert(result.decimals === 8, "decimals parsed correctly");
   assert(result.price === 10012345678n, "price parsed correctly");
+  assert(result.timestamp === 0, "timestamp defaults to 0 when not set");
 
   console.log("✓ parses valid oracle data");
+}
+
+// Timestamp parsing
+{
+  const ts = BigInt(Math.floor(Date.now() / 1000));
+  const buf = buildChainlinkBuffer(8, 5000000000n, 256, ts);
+  const result = parseChainlinkPrice(buf);
+  assert(result.timestamp === Number(ts), "timestamp parsed correctly");
+
+  console.log("✓ parses oracle timestamp");
 }
 
 // Different decimal values


### PR DESCRIPTION
## Summary
- `parseChainlinkPrice` now reads the unix timestamp at Chainlink offset 208
- `OraclePrice` interface extended with `timestamp: number` field
- `best-price` displays oracle age with human-readable format and `⚠ STALE` marker when > 2 minutes
- JSON output includes `timestamp` and `ageSecs` fields
- New test case verifying timestamp parsing

## Problem
`parseChainlinkPrice` only read price and decimals — the timestamp at offset 208 was completely ignored. The `best-price` command displayed oracle prices to traders with zero staleness information.

On devnet (and during oracle outages on mainnet), prices can be hours or days old. A trader seeing `$130.00` with no age indicator could execute a trade based on a price that is significantly out of date.

## Fix
Read the Chainlink timestamp field (offset 208, `u64 LE` unix seconds) and surface it through the interface. `best-price` computes age and displays it:
```
Oracle: $130.50
Oracle age: 15s
```
or
```
Oracle: $130.50
Oracle age: 2.5h ⚠ STALE
```

## Test plan
- [x] `tsup` build succeeds
- [x] All 48 tests pass (46 existing + 2 new oracle tests)
- [x] Verified timestamp offset matches `tests/t20-chainlink-oracle.ts:79`

🤖 Generated with [Claude Code](https://claude.com/claude-code)