### PR TITLE
fix: reject unknown slab data lengths instead of silent fallback

### DIFF
--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -440,12 +440,18 @@ function computeLayout(maxAccounts: number): SlabLayout {
   };
 }
 
+const KNOWN_CAPACITIES = [64, 256, 1024, 4096] as const;
+
 export function layoutForDataLength(dataLen: number): SlabLayout {
-  for (const cap of [64, 256, 1024, 4096]) {
+  for (const cap of KNOWN_CAPACITIES) {
     const l = computeLayout(cap);
     if (l.slabLen === dataLen) return l;
   }
-  return computeLayout(4096);
+  const known = KNOWN_CAPACITIES.map(c => `${c} (${computeLayout(c).slabLen} bytes)`).join(", ");
+  throw new Error(
+    `Slab data length ${dataLen} does not match any known layout. ` +
+    `Expected one of: ${known}`
+  );
 }
 
 // =============================================================================


### PR DESCRIPTION
layoutForDataLength silently returned the 4096 layout when data length didn't match any known capacity (64, 256, 1024, 4096). now it throws with a descriptive error listing expected sizes.

this prevented silent data corruption where every downstream parser (parseEngine, parseUsedIndices, parseAccount, computeCandidates) would read from wrong offsets on corrupt or unexpected accounts.

confirmed computeLayout(4096) still gives 1,525,624 (matches SLAB_LEN), all four capacity sizes resolve fine, bad lengths now throw instead of silently returning garbage, build passes, existing tests still green.