### PR TITLE
fix(liquidator): drop off-chain MM gate; engine price is stale between cranks

### DIFF
--- a/scripts/mainnet-liquidator.ts
+++ b/scripts/mainnet-liquidator.ts
@@ -1,31 +1,25 @@
 /**
  * Mainnet liquidator (one-shot, cron-driven at 60 s).
  *
- * Reads the slab once. Computes off-chain the engine's
- * `is_above_maintenance_margin` predicate per account and ONLY submits a
- * crank if at least one account appears to be below MM. This avoids
- * wasting a ~5000-lamport signature fee every minute during healthy
- * periods. The engine re-checks on-chain before liquidating, so a
- * false-positive candidate is a no-op there.
+ * Reads the slab. If any account has a non-zero position, submits a
+ * permissionless `KeeperCrank` with the two largest |position_basis_q|
+ * as `FullClose` candidates. The engine's `keeper_crank_not_atomic`
+ * uses the fresh Pyth price passed from the wrapper and is authoritative:
+ * if an account is healthy it's a no-op fee sync, if it's below MM it
+ * gets liquidated and the fee flows to insurance.
  *
- * Off-chain heuristic (conservative — may over-flag, never under-flag on
- * non-ADL'd accounts):
- *
- *   eq_approx   = capital + min(pnl, 0) - max(0, -fee_credits)    [drops positive
- *                                                                  matured_pnl
- *                                                                  which engine
- *                                                                  credits — can
- *                                                                  over-flag]
- *   notional    = |position_basis_q| * last_oracle_price / POS_SCALE(1_000_000)
- *   mm_req      = max(notional * mm_bps / 10000, min_nonzero_mm_req)
- *   LIQUIDATABLE iff eq_approx <= mm_req
- *
- * If the off-chain check fires, submit `KeeperCrank` with up to 2
- * liquidation-candidate accounts (LARGEST |position| first), FullClose
- * policy. Engine's `keeper_crank_not_atomic` runs the definitive check.
+ * No off-chain MM gate: `engine.last_oracle_price` is only written when
+ * an oracle-reading instruction (crank/trade/settle/liquidate/catchup)
+ * lands, so between cron ticks it can lag by the full crank interval.
+ * A gate computed from that value would under-flag exactly when price
+ * has moved — the case that most needs liquidation. The engine's
+ * on-chain check reads Pyth fresh each call, so over-submission is
+ * strictly safe; the saved ~5000-lamport signature per quiet minute
+ * (~0.0072 SOL/day ≈ $0.63/day at SOL=$87) is not worth the missed-
+ * liquidation risk.
  *
  * callerIdx = 65535 (permissionless). We don't run as an LP so we don't
- * earn the 50 % maintenance-fee reward kickback, but liquidation fees
+ * earn the 50% maintenance-fee reward kickback, but liquidation fees
  * flow to insurance and the market stays solvent.
  *
  * Exit codes: 0 always (idle counts as success). Emits a single LIQ_*
@@ -40,9 +34,7 @@ import * as fs from "fs";
 import { encodeKeeperCrank } from "../src/abi/instructions.js";
 import { ACCOUNTS_KEEPER_CRANK, buildAccountMetas, WELL_KNOWN } from "../src/abi/accounts.js";
 import { buildIx } from "../src/runtime/tx.js";
-import { parseEngine, parseParams, parseAccount, parseUsedIndices, fetchSlab } from "../src/solana/slab.js";
-
-const POS_SCALE = 1_000_000n;
+import { parseEngine, parseAccount, parseUsedIndices, fetchSlab } from "../src/solana/slab.js";
 
 function abs(x: bigint): bigint { return x < 0n ? -x : x; }
 
@@ -64,34 +56,20 @@ async function main() {
     console.log(`[${iso}] LIQ_HALT  market_mode=Resolved — nothing to do`);
     return;
   }
-  const p = parseParams(data);
   const used = parseUsedIndices(data);
-  const price = e.lastOraclePrice;
 
-  if (price === 0n) {
-    console.log(`[${iso}] LIQ_IDLE  engine.last_oracle_price=0 (pre-first-crank)`);
-    return;
-  }
-
-  // Collect liquidation candidates via off-chain health check.
-  type Cand = { idx: number; absPos: bigint; eq: bigint; mmReq: bigint };
+  // Collect every account with an open position. The engine's on-chain
+  // MM check (with fresh Pyth) is the authoritative filter.
+  type Cand = { idx: number; absPos: bigint };
   const cands: Cand[] = [];
   for (const i of used) {
     const a = parseAccount(data, i);
     if (a.positionBasisQ === 0n) continue;
-    const absPos = abs(a.positionBasisQ);
-    const notional = (absPos * price) / POS_SCALE;
-    const proportional = (notional * p.maintenanceMarginBps) / 10_000n;
-    const mmReq = proportional > p.minNonzeroMmReq ? proportional : p.minNonzeroMmReq;
-    // eq_approx = capital + min(pnl, 0) - max(0, -fee_credits)
-    const negPnl = a.pnl < 0n ? a.pnl : 0n;
-    const feeDebt = a.feeCredits < 0n ? -a.feeCredits : 0n;
-    const eq = BigInt(a.capital) + negPnl - feeDebt;
-    if (eq <= mmReq) cands.push({ idx: i, absPos, eq, mmReq });
+    cands.push({ idx: i, absPos: abs(a.positionBasisQ) });
   }
 
   if (cands.length === 0) {
-    console.log(`[${iso}] LIQ_IDLE  nUsed=${used.length} all accounts above MM`);
+    console.log(`[${iso}] LIQ_IDLE  nUsed=${used.length} no open positions`);
     return;
   }
 
@@ -122,7 +100,7 @@ async function main() {
   const postUsed = new Set(parseUsedIndices(await fetchSlab(conn, slab)));
   const insDelta = post.insuranceFund.balance - preInsurance;
   const liquidated = [...preUsed].filter(x => !postUsed.has(x));
-  const candList = top.map(c => `${c.idx}(eq=${c.eq},mm=${c.mmReq})`).join(",");
+  const candList = top.map(c => `${c.idx}(|pos|=${c.absPos})`).join(",");
   const tag = liquidated.length > 0 ? "LIQ_FIRE" : "LIQ_SYNC";
   console.log(`[${iso}] ${tag}  sig=${sig.slice(0, 24)}... cands=[${candList}] liquidated=[${liquidated.join(",") || "none"}] insDelta=${insDelta}`);
 }


### PR DESCRIPTION
## Summary

The off-chain `is_above_maintenance_margin` shortcut in `scripts/mainnet-liquidator.ts` reads `engine.last_oracle_price`, which is only written when an oracle-reading instruction (crank / trade / settle / liquidate / catchup) lands. Between cron ticks on a quiet market, that value lags by the full crank interval — currently ~1h. A gate computed from the lagged price under-flags exactly when price has moved against a position, which is the case that most needs liquidation, silently skipping submission and defeating the commit message's *"never under-flags on non-ADL'd positions"* guarantee.

This PR drops the off-chain filter. The script now always submits `KeeperCrank` with up to two candidates sorted by `|position_basis_q|` whenever any account has an open position. The engine's `keeper_crank_not_atomic` reads Pyth fresh each call via `read_price_and_stamp` (wrapper:5168 → :5370) and is authoritative, so over-submission is strictly safe — a healthy account is a no-op fee sync, and the real MM check happens on-chain against the fresh price.

## Details

The freshness boundary:

- `engine.last_oracle_price` (engine:2261) is written only inside `accrue_market_to`, called only from oracle-reading instructions.
- On a pre-liquidity / low-activity market, the hourly `mainnet-crank.ts` cron is the only guaranteed refresh. Between refreshes the price is cached.
- `mainnet-liquidator.ts` with the off-chain gate would return `LIQ_IDLE` without submitting a tx, so it never refreshes the price itself.
- In inverted markets (`engine_price = 1e12 / pyth_price`), a pyth drop raises engine_price, which raises notional and `mm_req`. An account above MM at the cached price can be below MM at the fresh price; the off-chain check uses the cached value and skips.
- Pnl-staleness cancels across off-chain and on-chain checks since both read `account.pnl` from the same slab state; the only divergence is the oracle price used in the notional calculation.

The direction is sign-independent — both long and short positions under-flag whenever engine_price rises between cranks, because notional scales with `|position_basis_q|`.

## Tradeoff

The original commit `e88649b` optimized away a ~5 000-lamport signature fee per quiet cron tick (~0.0072 SOL/day ≈ \$0.63/day at SOL=\$87, ~\$230/yr). That optimization is incompatible with its stated guarantee; a single missed liquidation during a real price move can cost insurance path-dependent losses that dwarf a year of unconditional cranks. Removing the parallel pricing path also eliminates the long-term sync burden against the wrapper's `read_pyth_price_e6` parser.

## Change

`scripts/mainnet-liquidator.ts`: 23 insertions, 45 deletions (header comment updated to reflect the new invariant). No other files touched. No new dependencies. No behavior change on fired ticks; the `top-2 by |position_basis_q|` ranking, `callerIdx=65535` permissionless flag, CU budget, priority fee, and log-tag semantics are unchanged.

## Test plan

- [x] `pnpm build` passes
- [ ] Devnet: run the updated liquidator against `dtrNVk7otCtcmPvrARnLxi5nWoNFYQYS7b9vC1Yjnt2` with 3 open positions; expect `LIQ_SYNC` on the first tick and subsequent cron ticks (idle is only when no open positions at all)
- [ ] Mainnet: cron-install on `5ZamUkAiXtvYQijNiRcuGaea66TVbbTPusHfwMX1kTqB`; monitor `LIQ_*` log lines for 24h to confirm no regressions