### PR TITLE
fix(close-all-slabs): respect global --simulate flag

### DIFF
--- a/src/commands/close-all-slabs.ts
+++ b/src/commands/close-all-slabs.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { PublicKey, Transaction, ComputeBudgetProgram, sendAndConfirmTransaction } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
 import { createContext } from "../runtime/context.js";
@@ -12,7 +12,7 @@ import {
   buildAccountMetas,
   WELL_KNOWN,
 } from "../abi/accounts.js";
-import { buildIx } from "../runtime/tx.js";
+import { buildIx, simulateOrSend } from "../runtime/tx.js";
 
 // PERCOLAT magic bytes for filtering
 const PERCOLAT_MAGIC = Buffer.from([0x50, 0x45, 0x52, 0x43, 0x4f, 0x4c, 0x41, 0x54]);
@@ -22,7 +22,7 @@ export function registerCloseAllSlabs(program: Command): void {
   program
     .command("close-all-slabs")
     .description("Find and close all slab accounts owned by the program (devnet cleanup)")
-    .option("--dry-run", "List slabs without closing them")
+    .option("--dry-run", "List slabs without closing them (no RPC tx; --dry-run takes precedence over --simulate)")
     .option("--limit <n>", "Maximum number of slabs to close", "100")
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
@@ -30,6 +30,7 @@ export function registerCloseAllSlabs(program: Command): void {
       const ctx = createContext(config);
 
       const dryRun = opts.dryRun ?? false;
+      const simulate = flags.simulate ?? false;
       const limit = parseInt(opts.limit, 10);
 
       console.log(`Searching for slab accounts owned by ${ctx.programId.toBase58()}...`);
@@ -65,6 +66,9 @@ export function registerCloseAllSlabs(program: Command): void {
         return;
       }
 
+      // --dry-run short-circuits before any tx building; --simulate is only
+      // consulted on the send path below. If both are passed, --dry-run wins
+      // (strictly cheaper — no RPC round-trip per slab).
       if (dryRun) {
         console.log("\nSlabs (dry run - not closing):");
         for (const { pubkey, account } of slabs.slice(0, limit)) {
@@ -76,13 +80,13 @@ export function registerCloseAllSlabs(program: Command): void {
         return;
       }
 
-      // Close slabs
+      // Close slabs (or simulate each close if --simulate is set).
       let closed = 0;
       let failed = 0;
       let totalRecovered = 0;
 
       const toClose = slabs.slice(0, limit);
-      console.log(`\nClosing ${toClose.length} slab(s)...`);
+      console.log(`\n${simulate ? "Simulating" : "Closing"} ${toClose.length} slab(s)...`);
 
       for (const { pubkey, account } of toClose) {
         try {
@@ -106,18 +110,27 @@ export function registerCloseAllSlabs(program: Command): void {
             data: ixData,
           });
 
-          const tx = new Transaction();
-          tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }));
-          tx.add(ix);
-
-          const sig = await sendAndConfirmTransaction(ctx.connection, tx, [ctx.payer], {
+          const result = await simulateOrSend({
+            connection: ctx.connection,
+            ix,
+            signers: [ctx.payer],
+            simulate,
             commitment: ctx.commitment,
+            computeUnitLimit: 1_400_000,
           });
+
+          if (result.err) {
+            failed++;
+            const short = result.err.length > 50 ? result.err.slice(0, 50) : result.err;
+            console.log(`  Failed ${pubkey.toBase58().slice(0, 8)}...: ${short}`);
+            continue;
+          }
 
           const solRecovered = account.lamports / 1e9;
           totalRecovered += solRecovered;
           closed++;
-          console.log(`  Closed ${pubkey.toBase58().slice(0, 8)}... (+${solRecovered.toFixed(4)} SOL)`);
+          const verb = simulate ? "Would close" : "Closed";
+          console.log(`  ${verb} ${pubkey.toBase58().slice(0, 8)}... (+${solRecovered.toFixed(4)} SOL)`);
         } catch (e: any) {
           failed++;
           console.log(`  Failed ${pubkey.toBase58().slice(0, 8)}...: ${e.message?.slice(0, 50)}`);
@@ -125,8 +138,8 @@ export function registerCloseAllSlabs(program: Command): void {
       }
 
       console.log(`\nSummary:`);
-      console.log(`  Closed: ${closed}`);
+      console.log(`  ${simulate ? "Would close" : "Closed"}: ${closed}`);
       console.log(`  Failed: ${failed}`);
-      console.log(`  SOL recovered: ${totalRecovered.toFixed(4)}`);
+      console.log(`  SOL ${simulate ? "recoverable" : "recovered"}: ${totalRecovered.toFixed(4)}`);
     });
 }


### PR DESCRIPTION
## Summary

The `close-all-slabs` command currently calls `sendAndConfirmTransaction` directly in its per-slab loop, so the global `--simulate` flag (defined at [src/cli.ts:56](../../blob/master/src/cli.ts#L56) and listed in `README.md` as a top-level CLI option) is silently dropped. Every other tx-submitting command in `src/commands/` routes through `simulateOrSend` ([src/runtime/tx.ts](../../blob/master/src/runtime/tx.ts)) and threads `flags.simulate`; the singular sibling [src/commands/close-slab.ts:59](../../blob/master/src/commands/close-slab.ts#L59) is the canonical reference pattern.

`CloseSlab` is terminal and irreversible. An operator running `percolator-cli close-all-slabs --simulate` reasonably expects no state change, but today every eligible slab in the signer's admin set is closed for real.

## Change

Swap the direct `sendAndConfirmTransaction` call for `simulateOrSend`, thread `flags.simulate`, and branch on the returned `result.err` (since `simulateOrSend` returns errors rather than throwing — the existing `try/catch` alone would have silently counted failed txs as succeeded).

Preserve the existing `--dry-run` path (list without building any tx) as the cheaper preview; add an inline comment noting that `--dry-run` takes precedence when both flags are passed, which is natural from the early-return control flow but made explicit for reviewers.

Output text reflects the mode: `Would close` / `recoverable` when `--simulate` is active, `Closed` / `recovered` otherwise.

## Semantics

- `(no flags)`: unchanged — close each eligible slab, same output format.
- `--dry-run`: unchanged — list pubkeys and total recoverable SOL, no tx built.
- `--simulate`: now simulates each close ix via `connection.simulateTransaction`, prints per-slab result, sends no tx.
- `--dry-run --simulate`: `--dry-run` wins (function returns before the send loop).
- `--limit N`: unchanged — applies to both the list and send paths.

## Test plan

- [x] `pnpm build` passes
- [ ] Devnet: `percolator-cli close-all-slabs --simulate` on a wallet owning N slabs; expect N `Would close ... (+X SOL)` lines and zero on-chain state change
- [ ] Devnet: `percolator-cli close-all-slabs --dry-run --simulate`; expect list-only behavior (dry-run precedence)
- [ ] Devnet: `percolator-cli close-all-slabs`; expect existing behavior, N `Closed` lines

## Scope

One file, +26 / -13. No public-facing flag changes; no new dependencies; no changes to `simulateOrSend` or `buildIx`.