### PR TITLE
fix(abi): remove AUTHORITY_KIND.CLOSE alias to prevent silent ADMIN rotation

### DIFF
--- a/src/abi/instructions.ts
+++ b/src/abi/instructions.ts
@@ -56,11 +56,24 @@ export const AUTHORITY_KIND = {
   ADMIN: 0,                // header.admin
   HYPERP_MARK: 1,          // config.hyperp_authority (renamed from oracle_authority in v12.20)
   INSURANCE: 2,            // header.insurance_authority — tag 20 WithdrawInsurance (unbounded)
-  // kind=3 CLOSE was deleted; close authority merged into ADMIN in v12.20
+  // kind=3 CLOSE was deleted; close authority merged into ADMIN in v12.20.
+  // No alias is provided — CLOSE and ADMIN control different scopes historically,
+  // and a silent alias would let pre-v12.20 scripts rotate ADMIN while believing
+  // they were rotating a narrower close key.
   INSURANCE_OPERATOR: 4,   // header.insurance_operator — tag 23 WithdrawInsuranceLimited
-  ORACLE: 1,               // back-compat alias for HYPERP_MARK
-  CLOSE: 0,                // back-compat alias — CloseSlab now gated on ADMIN
+  ORACLE: 1,               // back-compat alias for HYPERP_MARK (true v12.20 rename)
 } as const;
+
+/**
+ * Valid `kind` values for `encodeUpdateAuthority`. `CLOSE` (=3) was deleted
+ * in v12.20 and must not be reintroduced as an alias; see AUTHORITY_KIND above.
+ */
+const VALID_AUTHORITY_KINDS: ReadonlySet<number> = new Set([
+  AUTHORITY_KIND.ADMIN,
+  AUTHORITY_KIND.HYPERP_MARK,
+  AUTHORITY_KIND.INSURANCE,
+  AUTHORITY_KIND.INSURANCE_OPERATOR,
+]);
 
 /**
  * InitMarket wire layout (v12.20+):
@@ -391,10 +404,16 @@ export function encodeCatchupAccrue(): Buffer {
 
 // ---------- Authority management (replaces UpdateAdmin, SetOracleAuthority) ----------
 export interface UpdateAuthorityArgs {
-  kind: number; // AUTHORITY_KIND.ADMIN | ORACLE | INSURANCE | CLOSE
+  kind: number; // AUTHORITY_KIND.ADMIN | HYPERP_MARK (ORACLE) | INSURANCE | INSURANCE_OPERATOR
   newPubkey: PublicKey | string;
 }
 export function encodeUpdateAuthority(args: UpdateAuthorityArgs): Buffer {
+  if (!VALID_AUTHORITY_KINDS.has(args.kind)) {
+    throw new Error(
+      `encodeUpdateAuthority: invalid kind ${args.kind} ` +
+      `(expected 0=ADMIN, 1=HYPERP_MARK, 2=INSURANCE, 4=INSURANCE_OPERATOR)`
+    );
+  }
   return Buffer.concat([
     encU8(IX_TAG.UpdateAuthority),
     encU8(args.kind),


### PR DESCRIPTION
## Summary

[src/abi/instructions.ts:62](../../blob/master/src/abi/instructions.ts#L62) defines `AUTHORITY_KIND.CLOSE: 0` as a back-compat alias after v12.20 merged the separate close authority into admin (engine comment at `audit-src/percolator-prog/percolator.rs:3909`: *"Tag 3 (AUTHORITY_CLOSE) deleted — close_authority merged into admin"*). The alias has the numeric value `0`, identical to `ADMIN`.

A script that still imports `AUTHORITY_KIND.CLOSE` to rotate or burn what it believes is a narrow close authority silently rotates or burns `ADMIN` instead. `ADMIN` gates `UpdateConfig`, `SetOraclePriceCap`, `ResolveMarket`, `AdminForceCloseAccount`, `CloseSlab`, and `UpdateAuthority` itself — which can in turn rotate or burn every other authority. A silent rotation hands full market control to the destination pubkey; a silent burn (`newPubkey = Pubkey::default()`) puts the market permanently into the admin-free terminal state.

## Why a loud break is safer than a silent alias

`ORACLE: 1` is a legitimate v12.20 rename — `oracle_authority` was renamed to `hyperp_authority`, same slot, same value `1`. Keeping that alias is semantically faithful and this PR retains it.

`CLOSE: 0` is a semantic collapse onto a different authority, not a rename. The on-chain `close_authority` field was deleted; admin absorbed its role. Aliasing a removed-authority identifier to a different still-live authority is strictly more dangerous than letting the symbol go `undefined` — a caller on the legacy path gets a loud `TypeError` at import time instead of a successful-but-wrong transaction.

## Change

1. Delete `CLOSE: 0` from `AUTHORITY_KIND` in `src/abi/instructions.ts`.
2. Update the `UpdateAuthorityArgs.kind` JSDoc comment to drop `CLOSE` from the valid set.
3. Validate `args.kind` in `encodeUpdateAuthority` against `{0, 1, 2, 4}`. Throws a named error (`encodeUpdateAuthority: invalid kind ${kind} (expected 0=ADMIN, 1=HYPERP_MARK, 2=INSURANCE, 4=INSURANCE_OPERATOR)`) if a caller passes any other value — notably catches scripts hard-coding the old `kind: 3` wire value, surfacing the mistake at encode time instead of round-tripping to chain.

## Caller survey

Grep across the repo confirms no in-tree caller uses `AUTHORITY_KIND.CLOSE`. The four active call sites all pass valid kinds and continue to work unchanged:

- [src/commands/update-admin.ts:33](../../blob/master/src/commands/update-admin.ts#L33) — `kind: AUTHORITY_KIND.ADMIN`
- [src/commands/set-oracle-authority.ts:28](../../blob/master/src/commands/set-oracle-authority.ts#L28) — `kind: AUTHORITY_KIND.ORACLE`
- `encodeUpdateAdmin` back-compat shim at [src/abi/instructions.ts:418](../../blob/master/src/abi/instructions.ts#L418) — `ADMIN`
- `encodeSetOracleAuthority` back-compat shim at `src/abi/instructions.ts:411` — `ORACLE`

## Scope

One file, +23 / -4. No public-facing flag or CLI command changes. No new dependencies. `ORACLE` alias retained. Engine ABI unchanged (wire-format bytes identical for all valid inputs; only rejection behavior changes for invalid inputs).

## Test plan

- [x] `pnpm build` passes
- [ ] Manual: `encodeUpdateAuthority({ kind: 0, newPubkey })` (ADMIN) produces identical bytes as before
- [ ] Manual: `encodeUpdateAuthority({ kind: 3, newPubkey })` now throws `invalid kind 3 ...` at encode time rather than producing a rejected tx
- [ ] Manual: `AUTHORITY_KIND.CLOSE` is now `undefined`, breaking any external script that references it — intended