### PR TITLE
fix(dump-market): define missing threshold variable

### DIFF
--- a/scripts/dump-market.ts
+++ b/scripts/dump-market.ts
@@ -51,6 +51,7 @@ async function main() {
 
   // Derived engine values
   const insurance = engine.insuranceFund.balance;
+  const threshold = config.threshFloor;
   const surplus = insurance > threshold ? insurance - threshold : 0n;
 
   // Build accounts


### PR DESCRIPTION
## Summary

`scripts/dump-market.ts` crashes on every invocation with:

```
ReferenceError: threshold is not defined
    at main (scripts/dump-market.ts:54:31)
```

## Root cause

The runtime `threshold` field was removed from `EngineState.insuranceFund` — the parser in `src/solana/slab.ts:331` now exposes only `balance`:

```ts
export interface InsuranceFund { balance: bigint; }
```

The consumer in `scripts/dump-market.ts` was not updated when this field moved. Two sites reference the now-undefined identifier:

- L54: `const surplus = insurance > threshold ? insurance - threshold : 0n;`
- L206: `threshold: { raw: threshold.toString(), sol: sol(threshold) },`

The first reference throws before the second is reached, so the script fails fast at the top of `main()`.

## Fix

The configured insurance floor lives in `MarketConfig.threshFloor`, which is the natural source for the surplus-over-floor calculation that the script wants to surface. One added line resolves both call sites:

```ts
const insurance = engine.insuranceFund.balance;
const threshold = config.threshFloor;   // <-- added
const surplus = insurance > threshold ? insurance - threshold : 0n;
```

This preserves the existing JSON output shape under `engine.insuranceFund.threshold` — readers of the dump get the configured floor, which is the value `surplus` is computed against, so the two fields remain internally consistent.

## Test plan

- [x] `pnpm build` — clean
- [x] `npx tsx scripts/dump-market.ts` — no longer throws `ReferenceError` at L54; execution proceeds past insurance-fund derivation into account iteration

## Out of scope

After this fix, the script reveals a separate, unrelated drift further down (`acc.accountId.toString()` at L72 — `accountId` is undefined on the parsed account shape). That deserves its own PR — the field naming and account parser likely need to be reconciled together — and is left for a follow-up so this change stays minimal and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
