### PR TITLE
security(init-market): warn on min-oracle-price-cap=0 on non-Hyperp markets

### DIFF
--- a/src/commands/init-market.ts
+++ b/src/commands/init-market.ts
@@ -52,6 +52,7 @@ export function registerInitMarket(program: Command): void {
     .requiredOption("--funding-max-e9-per-slot <string>", "Funding max rate (i64 e9 parts-per-billion per slot; v12.18+)")
     .requiredOption("--mark-min-fee <string>", "Min fee for full mark weight (0=disabled)")
     .requiredOption("--force-close-delay <string>", "Force-close delay after resolve (slots)")
+    .option("--acknowledge-cap-disabled", "Suppress the cap=0 warning on non-Hyperp markets (intentional)", false)
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
@@ -66,6 +67,47 @@ export function registerInitMarket(program: Command): void {
         : (opts.indexFeedId as string);
       if (feedIdHex.length !== 64 || !/^[0-9a-fA-F]+$/.test(feedIdHex)) {
         throw new Error("Invalid feed ID: must be 64 hex characters");
+      }
+
+      // F7 safety check — non-Hyperp market with min_oracle_price_cap_e2bps = 0
+      // permanently installs an unclamped Pyth price path if admin is later
+      // burned. See percolator-prog/scripts/security.md F7 and PR #44 for the
+      // derived-cap invariant. Warn (do not block) unless acknowledged.
+      const isHyperp = /^0+$/.test(feedIdHex);
+      if (!isHyperp && opts.minOraclePriceCap === "0" && !opts.acknowledgeCapDisabled) {
+        const im = parseInt(opts.initialMarginBps, 10);
+        const mm = parseInt(opts.maintenanceMarginBps, 10);
+        const stale = parseInt(opts.maxCrankStaleness, 10);
+        const derived = Number.isFinite(im) && Number.isFinite(mm) && Number.isFinite(stale) && stale > 0
+          ? Math.floor(((im - mm) * 100) / stale)
+          : 0;
+        console.warn("");
+        console.warn("  ⚠  WARNING  min-oracle-price-cap = 0 on a non-Hyperp market");
+        console.warn("");
+        console.warn("     With cap = 0, clamp_oracle_price short-circuits and any Pyth");
+        console.warn("     observation writes last_effective_price_e6 unclamped. If the admin");
+        console.warn("     is subsequently burned, the per-update circuit breaker cannot be");
+        console.warn("     restored for the lifetime of this market.");
+        console.warn("");
+        console.warn("     Combined with the IM-vs-band gap, a single Pyth observation that");
+        console.warn("     moves baseline by more than initialMarginBps drives max-leveraged");
+        console.warn("     positions into bankruptcy; residual loss absorbs from the insurance");
+        console.warn("     fund via `use_insurance_buffer`.");
+        console.warn("");
+        console.warn("     See: percolator-prog/scripts/security.md § F7");
+        console.warn("          aeyakovenko/percolator-prog#35, #36, #43, PR #44");
+        console.warn("");
+        if (derived > 0) {
+          console.warn(`     Suggested: --min-oracle-price-cap ${derived}`);
+          console.warn(`     Derivation: (IM_bps - MM_bps) * 100 / max_crank_staleness_slots`);
+          console.warn(`               = (${im} - ${mm}) * 100 / ${stale} = ${derived}`);
+          console.warn(`     (matches @aeyakovenko's derived-cap invariant, PR #44.)`);
+          console.warn("");
+        }
+        console.warn("     Pass --acknowledge-cap-disabled to suppress this warning if the");
+        console.warn("     trade-off is intentional (e.g., Hyperp-style markets, or deployments");
+        console.warn("     that will keep admin live). Proceeding anyway.");
+        console.warn("");
       }
 
       const [vaultPda] = deriveVaultAuthority(ctx.programId, slabPk);


### PR DESCRIPTION
## Summary

One-shot console warning at `init-market` encode time when deployer passes a non-Hyperp `--index-feed-id` **and** leaves `--min-oracle-price-cap` at its `0` default. Prints the derived-cap suggestion using `(IM_bps - MM_bps) * 100 / max_crank_staleness_slots` (matches [@aeyakovenko's invariant in `percolator-prog#44`](https://github.com/aeyakovenko/percolator-prog/pull/44)).

Does **not** block — warning-only, passes through to encode/submit. Suppressible with `--acknowledge-cap-disabled` when the trade-off is intentional (e.g., pure Hyperp markets, or deployments that will keep admin live).

## Why

`min_oracle_price_cap_e2bps = 0` on a non-Hyperp market permanently disables the per-update Pyth circuit breaker. If the admin is subsequently burned, this state cannot be remediated on-chain for the lifetime of the market — the composition root of **F7** in `percolator-prog/scripts/security.md` (pending companion PR [`percolator-prog#47`](https://github.com/aeyakovenko/percolator-prog/pull/47)).

The underlying finding was surfaced between 2026-04-22 and 2026-04-23 across:
- [`percolator-prog#35`](https://github.com/aeyakovenko/percolator-prog/issues/35) `@jedsilver`
- [`percolator-prog#36`](https://github.com/aeyakovenko/percolator-prog/issues/36) `@alsk1992`
- [`percolator-prog#43`](https://github.com/aeyakovenko/percolator-prog/issues/43) `@abishekk92`
- [`percolator-cli#22`](https://github.com/aeyakovenko/percolator-cli/issues/22) `@abhay`
- [`percolator-cli#23`](https://github.com/aeyakovenko/percolator-cli/issues/23) `@Genmin`

Init-time engine fixes are landing in [`percolator-prog#41`](https://github.com/aeyakovenko/percolator-prog/pull/41) and [`percolator-prog#44`](https://github.com/aeyakovenko/percolator-prog/pull/44). This CLI PR adds the **tool-level** layer — so operators using `percolator-cli` get an actionable prompt at configuration time, before any on-chain submission.

## Style precedent

Mirrors the defensive-warning pattern landed by `@0x-SquidSol`:
- [`percolator-cli#15`](https://github.com/aeyakovenko/percolator-cli/pull/15) — oracle timestamp staleness warning
- [`percolator-cli#12`](https://github.com/aeyakovenko/percolator-cli/pull/12) — client-side slippage protection
- [`percolator-cli#11`](https://github.com/aeyakovenko/percolator-cli/pull/11) — slab account-ownership verification

## Scope

One file: `src/commands/init-market.ts`. +42 / -0.
No wire-format changes. No new runtime dependencies.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm build` (tsup) clean — 128.44 KB ESM, no type errors
- [ ] Manual: `init-market --index-feed-id <zeros> --min-oracle-price-cap 0` → **no warning** (Hyperp market)
- [ ] Manual: `init-market --index-feed-id <sol-usd> --min-oracle-price-cap 0` → **warning printed** with derived suggestion
- [ ] Manual: `init-market --index-feed-id <sol-usd> --min-oracle-price-cap 500` → **no warning**
- [ ] Manual: `init-market --index-feed-id <sol-usd> --min-oracle-price-cap 0 --acknowledge-cap-disabled` → **no warning** (suppressed)

## Why now

The immutable mainnet instance at `5ZamU…kTqB` cannot benefit — its market is already configured and admin already burned. This PR is forward-looking: any future deployer running `percolator-cli init-market` against a fresh slab gets the named failure mode surfaced at configuration time instead of post-burn.

— Fasad Salatov