### PR TITLE
[codex] Harden CLI safety defaults and slab discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,29 @@ pnpm build
 
 ## Configuration
 
-Create a config file at `~/.config/percolator-cli.json`:
+Create a config file named `percolator-cli.json` in the directory where you run
+the CLI, or at `~/.config/percolator-cli.json`. You can also pass another path
+explicitly with `--config <path>`.
 
 ```json
 {
   "rpcUrl": "https://api.devnet.solana.com",
   "programId": "2SSnp35m7FQ7cRLNKGdW5UzjYFF6RBUNq7d3m5mqNByp",
-  "walletPath": "~/.config/solana/id.json"
+  "wallet": "~/.config/solana/id.json",
+  "commitment": "confirmed"
 }
 ```
 
 Or use command-line flags:
+- `--config <path>` - Path to config file
 - `--rpc <url>` - Solana RPC endpoint
 - `--program <pubkey>` - Percolator program ID
 - `--wallet <path>` - Path to keypair file
+- `--commitment <level>` - Commitment level: `processed`, `confirmed`, or `finalized`
 - `--json` - Output in JSON format
-- `--simulate` - Simulate transaction without sending
+- `--simulate` - Simulate transaction without sending. This is the default for transaction commands.
+- `--send` - Send a transaction instead of simulating it.
+- `--yes-mainnet` - Allow `--send` when the RPC URL appears to target mainnet.
 
 ## Mainnet Bounty 3 — `bounty_sol_20x_max`
 
@@ -519,7 +526,7 @@ percolator-cli trade-nocpi --slab <pubkey> --user-idx <n> --lp-idx <n> \
   --size <i128> --oracle <pubkey>
 
 # Close account
-percolator-cli close-account --slab <pubkey> --idx <n>
+percolator-cli close-account --slab <pubkey> --user-idx <n> --oracle <pubkey>
 ```
 
 ### LP Operations
@@ -530,14 +537,16 @@ percolator-cli init-lp --slab <pubkey>
 
 # Trade with CPI (matcher)
 percolator-cli trade-cpi --slab <pubkey> --user-idx <n> --lp-idx <n> \
-  --size <i128> --matcher-program <pubkey> --matcher-ctx <pubkey>
+  --size <i128> --matcher-program <pubkey> --matcher-context <pubkey> \
+  --limit-price-e6 <n> --oracle <pubkey>
 ```
 
 ### Keeper Operations
 
 ```bash
 # Crank the keeper (liquidations are processed automatically during crank)
-percolator-cli keeper-crank --slab <pubkey> --nonce <n> --oracle <pubkey>
+percolator-cli keeper-crank --slab <pubkey> --oracle <pubkey> \
+  --caller-idx <n> --compute-units <n>
 ```
 
 ### Admin Operations
@@ -549,21 +558,15 @@ percolator-cli update-admin --slab <pubkey> --new-admin <pubkey>
 # Top up insurance fund
 percolator-cli topup-insurance --slab <pubkey> --amount <lamports>
 
-# Update market configuration (funding and threshold params)
+# Update market configuration (funding and TVL cap params).
+# Omitted flags keep their current on-chain values.
 percolator-cli update-config --slab <pubkey> \
   --funding-horizon-slots <n> \
   --funding-k-bps <n> \
-  --funding-scale-notional-e6 <n> \
   --funding-max-premium-bps <n> \
-  --funding-max-bps-per-slot <n> \
-  --thresh-floor <n> \
-  --thresh-risk-bps <n> \
-  --thresh-update-interval-slots <n> \
-  --thresh-step-bps <n> \
-  --thresh-alpha-bps <n> \
-  --thresh-min <n> \
-  --thresh-max <n> \
-  --thresh-min-step <n>
+  --funding-max-e9-per-slot <n> \
+  --tvl-insurance-cap-mult <n> \
+  --oracle <pubkey>
 ```
 
 ### Oracle Authority (Admin Only)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "percolator-cli",
   "version": "0.1.0",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.31.0",
   "type": "module",
   "bin": {
     "percolator-cli": "./dist/index.js"
@@ -12,7 +13,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "pnpm build && node dist/index.js",
-    "test": "tsx test/abi.test.ts && tsx test/pda.test.ts && tsx test/slab.test.ts && tsx test/validation.test.ts && tsx test/oracle.test.ts"
+    "test": "tsx test/abi.test.ts && tsx test/pda.test.ts && tsx test/slab.test.ts && tsx test/slab-discovery.test.ts && tsx test/validation.test.ts && tsx test/oracle.test.ts && tsx test/config.test.ts && tsx test/context.test.ts && tsx test/tx.test.ts && tsx test/mainnet-bounty3-tick.test.ts"
   },
   "dependencies": {
     "@pythnetwork/hermes-client": "^2.1.0",

--- a/scripts/check-maint-fees.ts
+++ b/scripts/check-maint-fees.ts
@@ -35,14 +35,13 @@ import {
   buildAccountMetas, WELL_KNOWN,
 } from "../src/abi/accounts.js";
 import { buildIx } from "../src/runtime/tx.js";
-import { parseEngine, parseAccount, fetchSlab } from "../src/solana/slab.js";
+import { parseEngine, parseAccount, fetchSlab, SLAB_LEN } from "../src/solana/slab.js";
 import { deriveVaultAuthority, deriveLpPda } from "../src/solana/pda.js";
 import { defaultInitMarketArgs } from "./_default-market.js";
 
 const RPC = process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com";
 const PROG = new PublicKey("4PTXCZ4vLSK6aiUd3fx2dVVYSRNFnMSM4ijhDWkuFi2s");
 const MATCHER = new PublicKey("5ogNxr4uFXZXoeJ4cP89kKZkx1FkbaD2FBQr91KoYZep");
-const SLAB_SIZE = 1755376;
 const MAINT_FEE_PER_SLOT = "1000000"; // 1M engine units per slot per account
 
 const conn = new Connection(RPC, "confirmed");
@@ -75,11 +74,11 @@ async function main() {
   const slab = Keypair.generate();
   const mint = await createMint(conn, payer, payer.publicKey, null, 6);
   const [vaultAuth] = deriveVaultAuthority(PROG, slab.publicKey);
-  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_SIZE);
+  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_LEN);
 
   await tx([SystemProgram.createAccount({
     fromPubkey: payer.publicKey, newAccountPubkey: slab.publicKey,
-    lamports: rent, space: SLAB_SIZE, programId: PROG,
+    lamports: rent, space: SLAB_LEN, programId: PROG,
   })], [payer, slab], 50_000);
 
   const vAcc = await getOrCreateAssociatedTokenAccount(conn, payer, mint, vaultAuth, true);

--- a/scripts/dump-market.ts
+++ b/scripts/dump-market.ts
@@ -222,7 +222,7 @@ async function main() {
       sweep: {
         rrCursorPosition: engine.rrCursorPosition.toString(),
         sweepGeneration: engine.sweepGeneration.toString(),
-        priceMoveConsumedBpsThisGeneration: engine.priceMoveConsumedBpsThisGeneration.toString(),
+        stressConsumedBpsE9SinceEnvelope: engine.stressConsumedBpsE9SinceEnvelope.toString(),
       },
       sides: {
         long: {

--- a/scripts/live-verify.ts
+++ b/scripts/live-verify.ts
@@ -38,7 +38,7 @@ import {
   parseHeader, parseConfig, parseEngine, parseParams,
   parseAllAccounts, parseUsedIndices, parseAccount, fetchSlab,
   isAccountUsed,
-  type SlabHeader, type MarketConfig, type EngineState, type RiskParams, type Account,
+  SLAB_LEN, type SlabHeader, type MarketConfig, type EngineState, type RiskParams, type Account,
 } from "../src/solana/slab.js";
 import { deriveVaultAuthority, deriveLpPda } from "../src/solana/pda.js";
 
@@ -46,7 +46,6 @@ const RPC = process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com";
 const PROG = new PublicKey("4PTXCZ4vLSK6aiUd3fx2dVVYSRNFnMSM4ijhDWkuFi2s");
 const MATCHER_PROGRAM = new PublicKey("5ogNxr4uFXZXoeJ4cP89kKZkx1FkbaD2FBQr91KoYZep");
 const PYTH_ORACLE = new PublicKey("A7s72ttVi1uvZfe49GRggPEkcc6auBNXWivGWhSL9TzJ");
-const SLAB_SIZE = 1755376;
 const conn = new Connection(RPC, "confirmed");
 const payer = Keypair.fromSecretKey(new Uint8Array(
   JSON.parse(fs.readFileSync(`${process.env.HOME}/.config/solana/id.json`, "utf8"))
@@ -118,11 +117,11 @@ async function main() {
   const slab = Keypair.generate();
   const mint = await createMint(conn, payer, payer.publicKey, null, 6);
   const [vaultPda] = deriveVaultAuthority(PROG, slab.publicKey);
-  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_SIZE);
+  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_LEN);
 
   await tx([SystemProgram.createAccount({
     fromPubkey: payer.publicKey, newAccountPubkey: slab.publicKey,
-    lamports: rent, space: SLAB_SIZE, programId: PROG,
+    lamports: rent, space: SLAB_LEN, programId: PROG,
   })], [payer, slab], 100000);
 
   const vaultAcc = await getOrCreateAssociatedTokenAccount(conn, payer, mint, vaultPda, true);

--- a/scripts/mainnet-bounty2-tick.ts
+++ b/scripts/mainnet-bounty2-tick.ts
@@ -12,7 +12,7 @@
  *        - rrCursorPosition + sweepGeneration (sweep liveness)
  *        - lastOraclePrice change (oracle moved)
  *        - sideMode_long / sideMode_short (anything ≠ Normal = liquidation cascade)
- *        - price_move_consumed_bps_this_generation vs threshold
+ *        - stress_consumed_bps_e9_since_envelope vs threshold
  *        - last_market_slot vs current slot (accrue staleness)
  *   5. Conservation checks: vault SPL == engine.vault, vault >= cTot + insurance.
  *   6. Writes one JSON line to ~/.cache/percolator/bounty2-tick.log per tick.
@@ -81,7 +81,7 @@ async function snap(conn: Connection, slab: PublicKey, vault: PublicKey): Promis
     sideModeShort: e.sideModeShort,
     rrCursor: e.rrCursorPosition,
     sweepGen: e.sweepGeneration,
-    priceMoveConsumed: e.priceMoveConsumedBpsThisGeneration,
+    priceMoveConsumed: e.stressConsumedBpsE9SinceEnvelope,
     conservationOk: e.vault === BigInt(splBal),
     accountingOk: e.vault >= e.cTot + e.insuranceFund.balance,
   };

--- a/scripts/mainnet-bounty3-tick.ts
+++ b/scripts/mainnet-bounty3-tick.ts
@@ -36,12 +36,13 @@ import { getAccount } from "@solana/spl-token";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { fileURLToPath } from "url";
 import { encodeKeeperCrank } from "../src/abi/instructions.js";
 import { ACCOUNTS_KEEPER_CRANK, buildAccountMetas, WELL_KNOWN } from "../src/abi/accounts.js";
 import { buildIx } from "../src/runtime/tx.js";
 import { fetchSlab, parseHeader, parseConfig, parseEngine, parseUsedIndices } from "../src/solana/slab.js";
 
-type Snapshot = {
+export type Snapshot = {
   iso: string;
   slot: number;
   marketSlot: bigint;
@@ -81,13 +82,13 @@ async function snap(conn: Connection, slab: PublicKey, vault: PublicKey): Promis
     sideModeShort: e.sideModeShort,
     rrCursor: e.rrCursorPosition,
     sweepGen: e.sweepGeneration,
-    priceMoveConsumed: e.priceMoveConsumedBpsThisGeneration,
+    priceMoveConsumed: e.stressConsumedBpsE9SinceEnvelope,
     conservationOk: e.vault === BigInt(splBal),
     accountingOk: e.vault >= e.cTot + e.insuranceFund.balance,
   };
 }
 
-function diff(a: Snapshot, b: Snapshot): { flags: string[]; deltas: Record<string, string> } {
+export function diff(a: Snapshot, b: Snapshot): { flags: string[]; deltas: Record<string, string> } {
   const flags: string[] = [];
   const deltas: Record<string, string> = {};
   if (b.insurance < a.insurance) {
@@ -469,13 +470,15 @@ async function main() {
   });
 }
 
-main().catch(e => {
-  // Last-ditch: write a single error line and exit 0 so cron doesn't retry.
-  const logDir = path.join(os.homedir(), ".cache", "percolator");
-  try { fs.mkdirSync(logDir, { recursive: true }); } catch {}
-  try {
-    fs.appendFileSync(path.join(logDir, "bounty3-tick.log"),
-      JSON.stringify({ iso: new Date().toISOString(), event: "FATAL", err: String(e).slice(0, 300) }) + "\n");
-  } catch {}
-  process.exit(0);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(e => {
+    // Last-ditch: write a single error line and exit 0 so cron doesn't retry.
+    const logDir = path.join(os.homedir(), ".cache", "percolator");
+    try { fs.mkdirSync(logDir, { recursive: true }); } catch {}
+    try {
+      fs.appendFileSync(path.join(logDir, "bounty3-tick.log"),
+        JSON.stringify({ iso: new Date().toISOString(), event: "FATAL", err: String(e).slice(0, 300) }) + "\n");
+    } catch {}
+    process.exit(0);
+  });
+}

--- a/scripts/stress-bankrun.ts
+++ b/scripts/stress-bankrun.ts
@@ -35,13 +35,12 @@ import {
 import { buildIx } from "../src/runtime/tx.js";
 import {
   parseHeader, parseConfig, parseEngine, parseParams,
-  parseUsedIndices, parseAccount, fetchSlab, isAccountUsed,
+  parseUsedIndices, parseAccount, fetchSlab, isAccountUsed, SLAB_LEN,
 } from "../src/solana/slab.js";
 import { deriveVaultAuthority, deriveLpPda } from "../src/solana/pda.js";
 
 const PROG = new PublicKey("4PTXCZ4vLSK6aiUd3fx2dVVYSRNFnMSM4ijhDWkuFi2s");
 const MATCHER = new PublicKey("5ogNxr4uFXZXoeJ4cP89kKZkx1FkbaD2FBQr91KoYZep");
-const SLAB_SIZE = 1755376;
 const conn = new Connection(process.env.SOLANA_RPC_URL!, "confirmed");
 const payer = Keypair.fromSecretKey(new Uint8Array(
   JSON.parse(fs.readFileSync(`${process.env.HOME}/.config/solana/id.json`, "utf8"))
@@ -104,10 +103,10 @@ async function main() {
   const slab = Keypair.generate();
   const mint = await createMint(conn, payer, payer.publicKey, null, 6);
   const [vaultPda] = deriveVaultAuthority(PROG, slab.publicKey);
-  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_SIZE);
+  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_LEN);
   await tx([SystemProgram.createAccount({
     fromPubkey: payer.publicKey, newAccountPubkey: slab.publicKey,
-    lamports: rent, space: SLAB_SIZE, programId: PROG,
+    lamports: rent, space: SLAB_LEN, programId: PROG,
   })], [payer, slab], 100000);
   const vaultAcc = await getOrCreateAssociatedTokenAccount(conn, payer, mint, vaultPda, true);
   const vault = vaultAcc.address;

--- a/scripts/test-deep-invariants.ts
+++ b/scripts/test-deep-invariants.ts
@@ -38,12 +38,11 @@ import { deriveVaultAuthority, deriveLpPda } from "../src/solana/pda.js";
 import { buildIx } from "../src/runtime/tx.js";
 import {
   fetchSlab, parseEngine, parseAccount, parseUsedIndices, parseParams,
-  AccountKind,
+  AccountKind, SLAB_LEN,
 } from "../src/solana/slab.js";
 
 const PROGRAM_ID = new PublicKey("4PTXCZ4vLSK6aiUd3fx2dVVYSRNFnMSM4ijhDWkuFi2s");
 const MATCHER_PROGRAM_ID = new PublicKey("5ogNxr4uFXZXoeJ4cP89kKZkx1FkbaD2FBQr91KoYZep");
-const SLAB_SIZE = 1755376;
 const MATCHER_CTX_SIZE = 320;
 
 const payer = Keypair.fromSecretKey(
@@ -67,12 +66,12 @@ async function sim(tx: Transaction, signers: Keypair[]): Promise<boolean> {
 // Create a fresh isolated Hyperp market for each test group
 async function createMarket(initialPrice: string, insuranceSOL: number, lpSOL: number) {
   const slab = Keypair.generate();
-  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_SIZE);
+  const rent = await conn.getMinimumBalanceForRentExemption(SLAB_LEN);
   const t1 = new Transaction();
   t1.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 100000 }));
   t1.add(SystemProgram.createAccount({
     fromPubkey: payer.publicKey, newAccountPubkey: slab.publicKey,
-    lamports: rent, space: SLAB_SIZE, programId: PROGRAM_ID,
+    lamports: rent, space: SLAB_LEN, programId: PROGRAM_ID,
   }));
   await send(t1, [payer, slab]);
 

--- a/scripts/test-hyperp-market.ts
+++ b/scripts/test-hyperp-market.ts
@@ -70,13 +70,12 @@ import {
   buildAccountMetas,
 } from "../src/abi/accounts.js";
 import { deriveVaultAuthority, deriveLpPda } from "../src/solana/pda.js";
-import { fetchSlab, parseHeader, parseConfig, parseEngine, parseUsedIndices, parseAccount, AccountKind } from "../src/solana/slab.js";
+import { fetchSlab, parseHeader, parseConfig, parseEngine, parseUsedIndices, parseAccount, AccountKind, SLAB_LEN } from "../src/solana/slab.js";
 import { buildIx } from "../src/runtime/tx.js";
 
 // Program IDs
 const PROGRAM_ID = new PublicKey("4PTXCZ4vLSK6aiUd3fx2dVVYSRNFnMSM4ijhDWkuFi2s");
 const MATCHER_PROGRAM_ID = new PublicKey("5ogNxr4uFXZXoeJ4cP89kKZkx1FkbaD2FBQr91KoYZep");
-const SLAB_SIZE = 1525624;
 const MATCHER_CTX_SIZE = 320;
 
 const conn = new Connection(process.env.SOLANA_RPC_URL || "https://api.devnet.solana.com", "confirmed");
@@ -104,7 +103,7 @@ async function main() {
 
   // Create slab account
   slab = Keypair.generate();
-  const rentExempt = await conn.getMinimumBalanceForRentExemption(SLAB_SIZE);
+  const rentExempt = await conn.getMinimumBalanceForRentExemption(SLAB_LEN);
   console.log(`  Creating slab account: ${slab.publicKey.toBase58()}`);
 
   const createSlabTx = new Transaction();
@@ -113,7 +112,7 @@ async function main() {
     fromPubkey: payer.publicKey,
     newAccountPubkey: slab.publicKey,
     lamports: rentExempt,
-    space: SLAB_SIZE,
+    space: SLAB_LEN,
     programId: PROGRAM_ID,
   }));
   await sendAndConfirmTransaction(conn, createSlabTx, [payer, slab], { commitment: "confirmed" });

--- a/scripts/test-keeper-candidates.ts
+++ b/scripts/test-keeper-candidates.ts
@@ -33,12 +33,11 @@ import { deriveVaultAuthority, deriveLpPda } from "../src/solana/pda.js";
 import { buildIx } from "../src/runtime/tx.js";
 import {
   fetchSlab, parseEngine, parseAccount, parseUsedIndices, parseParams,
-  AccountKind,
+  AccountKind, SLAB_LEN,
 } from "../src/solana/slab.js";
 
 const PROGRAM_ID = new PublicKey("4PTXCZ4vLSK6aiUd3fx2dVVYSRNFnMSM4ijhDWkuFi2s");
 const MATCHER_PROGRAM_ID = new PublicKey("5ogNxr4uFXZXoeJ4cP89kKZkx1FkbaD2FBQr91KoYZep");
-const SLAB_SIZE = 1525624;
 const MATCHER_CTX_SIZE = 320;
 
 const payer = Keypair.fromSecretKey(
@@ -102,12 +101,12 @@ async function main() {
   console.log("\n--- Setup: Fresh Hyperp market ---");
 
   const slab = Keypair.generate();
-  const rentExempt = await conn.getMinimumBalanceForRentExemption(SLAB_SIZE);
+  const rentExempt = await conn.getMinimumBalanceForRentExemption(SLAB_LEN);
   const createTx = new Transaction();
   createTx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 100000 }));
   createTx.add(SystemProgram.createAccount({
     fromPubkey: payer.publicKey, newAccountPubkey: slab.publicKey,
-    lamports: rentExempt, space: SLAB_SIZE, programId: PROGRAM_ID,
+    lamports: rentExempt, space: SLAB_LEN, programId: PROGRAM_ID,
   }));
   await send(createTx, [payer, slab]);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { GlobalFlags } from "./config.js";
+import { resolveTxMode } from "./runtime/tx.js";
 
 // Import commands
 import { registerInitMarket } from "./commands/init-market.js";
@@ -53,7 +54,9 @@ export function createCli(): Command {
       "Commitment level: processed, confirmed, finalized"
     )
     .option("--json", "Output in JSON format")
-    .option("--simulate", "Simulate transaction without sending");
+    .option("--simulate", "Simulate transaction without sending")
+    .option("--send", "Send transaction. Without this flag, transaction commands simulate by default.")
+    .option("--yes-mainnet", "Allow --send when the RPC URL appears to target mainnet");
 
   // Register all commands
   registerInitMarket(program);
@@ -98,6 +101,11 @@ export function createCli(): Command {
  */
 export function getGlobalFlags(cmd: Command): GlobalFlags {
   const opts = cmd.optsWithGlobals();
+  const txMode = resolveTxMode({
+    simulate: opts.simulate ?? false,
+    send: opts.send ?? false,
+  });
+
   return {
     config: opts.config,
     rpc: opts.rpc,
@@ -105,6 +113,8 @@ export function getGlobalFlags(cmd: Command): GlobalFlags {
     wallet: opts.wallet,
     commitment: opts.commitment,
     json: opts.json ?? false,
-    simulate: opts.simulate ?? false,
+    simulate: txMode.simulate,
+    send: opts.send ?? false,
+    yesMainnet: opts.yesMainnet ?? false,
   };
 }

--- a/src/commands/audit-cu.ts
+++ b/src/commands/audit-cu.ts
@@ -1,7 +1,5 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
-import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
 import { TxResult } from "../runtime/tx.js";
 import { validateU32 } from "../validation.js";
 

--- a/src/commands/best-price.ts
+++ b/src/commands/best-price.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { Connection, PublicKey } from "@solana/web3.js";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseUsedIndices, parseAccount, AccountKind } from "../solana/slab.js";
 import { parseChainlinkPrice } from "../solana/oracle.js";
 import { validatePublicKey } from "../validation.js";
@@ -132,7 +132,7 @@ export function registerBestPrice(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const oraclePk = validatePublicKey(opts.oracle, "--oracle");

--- a/src/commands/close-account.ts
+++ b/src/commands/close-account.ts
@@ -82,6 +82,8 @@ export function registerCloseAccount(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/close-all-slabs.ts
+++ b/src/commands/close-all-slabs.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
-import { parseConfig } from "../solana/slab.js";
+import { createContext, createReadOnlyContext } from "../runtime/context.js";
+import { hasSlabMagic, parseConfig, slabMagicMemcmpFilter, SLAB_LEN } from "../solana/slab.js";
 import { getAta } from "../solana/ata.js";
 import { deriveVaultAuthority } from "../solana/pda.js";
 import { encodeCloseSlab } from "../abi/instructions.js";
@@ -14,12 +14,6 @@ import {
 import { buildIx, simulateOrSend } from "../runtime/tx.js";
 import { validateU32 } from "../validation.js";
 
-// PERCOLAT magic — stored on chain as LE bytes of 0x504552434f4c4154n.
-// The on-disk byte sequence is therefore "TALOCREP" (LE), not "PERCOLAT"
-// (BE). The previous BE constant matched zero accounts.
-const PERCOLAT_MAGIC = Buffer.from([0x54, 0x41, 0x4c, 0x4f, 0x43, 0x52, 0x45, 0x50]);
-const SLAB_SIZE = 1755376; // v12.21+ layout (old 1525624 markets long-closed)
-
 export function registerCloseAllSlabs(program: Command): void {
   program
     .command("close-all-slabs")
@@ -29,35 +23,32 @@ export function registerCloseAllSlabs(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const readCtx = createReadOnlyContext(config);
 
       const dryRun = opts.dryRun ?? false;
       const limit = validateU32(opts.limit, "--limit");
 
-      console.log(`Searching for slab accounts owned by ${ctx.programId.toBase58()}...`);
+      console.log(`Searching for slab accounts owned by ${readCtx.programId.toBase58()}...`);
 
       // Find all program accounts with the correct size
       let accounts;
       try {
-        accounts = await ctx.connection.getProgramAccounts(ctx.programId, {
+        accounts = await readCtx.connection.getProgramAccounts(readCtx.programId, {
           filters: [
-            { dataSize: SLAB_SIZE },
+            { dataSize: SLAB_LEN },
           ],
         });
       } catch (e: any) {
         // Fallback for RPC providers that don't support getProgramAccounts well
         console.log("getProgramAccounts failed, trying memcmp filter...");
-        accounts = await ctx.connection.getProgramAccounts(ctx.programId, {
-          filters: [
-            { memcmp: { offset: 0, bytes: PERCOLAT_MAGIC.toString("base64") } },
-          ],
+        accounts = await readCtx.connection.getProgramAccounts(readCtx.programId, {
+          filters: [slabMagicMemcmpFilter()],
         });
       }
 
       // Filter to only include accounts with PERCOLAT magic
       const slabs = accounts.filter(({ account }) => {
-        if (account.data.length < 8) return false;
-        return account.data.subarray(0, 8).equals(PERCOLAT_MAGIC);
+        return hasSlabMagic(account.data);
       });
 
       console.log(`Found ${slabs.length} slab account(s)`);
@@ -78,8 +69,9 @@ export function registerCloseAllSlabs(program: Command): void {
         return;
       }
 
-      // Close slabs (or simulate). CloseSlab is terminal — without --simulate
-      // each iteration is irreversible.
+      // Close slabs (or simulate). CloseSlab is terminal; --send is required
+      // to perform it because transaction commands simulate by default.
+      const ctx = createContext(config);
       let succeeded = 0;
       let failed = 0;
       let totalRecovered = 0;
@@ -118,6 +110,8 @@ export function registerCloseAllSlabs(program: Command): void {
             simulate,
             commitment: ctx.commitment,
             computeUnitLimit: 1_400_000,
+            rpcUrl: config.rpcUrl,
+            allowMainnet: flags.yesMainnet ?? false,
           });
 
           if (result.err) {

--- a/src/commands/close-slab.ts
+++ b/src/commands/close-slab.ts
@@ -62,6 +62,8 @@ export function registerCloseSlab(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/deposit.ts
+++ b/src/commands/deposit.ts
@@ -67,6 +67,8 @@ export function registerDeposit(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/init-lp.ts
+++ b/src/commands/init-lp.ts
@@ -68,6 +68,8 @@ export function registerInitLp(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/init-market.ts
+++ b/src/commands/init-market.ts
@@ -123,6 +123,8 @@ export function registerInitMarket(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
         // Full MAX_ACCOUNTS=4096 init_in_place consumes ~235k CU zero-filling
         // bitmap + next_free/prev_free + all 4096 account slots. Default
         // 200k-per-ix budget is not enough; 300k covers + headroom.

--- a/src/commands/init-user.ts
+++ b/src/commands/init-user.ts
@@ -60,6 +60,8 @@ export function registerInitUser(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/keeper-crank.ts
+++ b/src/commands/keeper-crank.ts
@@ -146,6 +146,8 @@ export function registerKeeperCrank(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
         computeUnitLimit,
       });
 

--- a/src/commands/liquidate-at-oracle.ts
+++ b/src/commands/liquidate-at-oracle.ts
@@ -50,6 +50,8 @@ export function registerLiquidateAtOracle(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/list-markets.ts
+++ b/src/commands/list-markets.ts
@@ -2,15 +2,8 @@ import { Command } from "commander";
 import { PublicKey } from "@solana/web3.js";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
-import { parseHeader, parseConfig, parseEngine, parseParams } from "../solana/slab.js";
-
-// PERCOLAT magic bytes
-const PERCOLAT_MAGIC = Buffer.from([0x50, 0x45, 0x52, 0x43, 0x4f, 0x4c, 0x41, 0x54]);
-// Slab size after ADL refactor
-// = ENGINE_OFF(440) + ENGINE_ACCOUNTS_OFF(9336) + MAX_ACCOUNTS(4096) * ACCOUNT_SIZE(280)
-const SLAB_SIZE = 1525624;
-
+import { createReadOnlyContext } from "../runtime/context.js";
+import { hasSlabMagic, parseHeader, parseConfig, parseEngine, parseParams, slabMagicMemcmpFilter, SLAB_LEN } from "../solana/slab.js";
 export function registerListMarkets(program: Command): void {
   program
     .command("list-markets")
@@ -19,7 +12,7 @@ export function registerListMarkets(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
       const verbose = opts.verbose ?? false;
       const json = flags.json ?? false;
 
@@ -29,21 +22,18 @@ export function registerListMarkets(program: Command): void {
       let accounts;
       try {
         accounts = await ctx.connection.getProgramAccounts(ctx.programId, {
-          filters: [{ dataSize: SLAB_SIZE }],
+          filters: [{ dataSize: SLAB_LEN }],
         });
       } catch {
         // Fallback with memcmp filter
         accounts = await ctx.connection.getProgramAccounts(ctx.programId, {
-          filters: [
-            { memcmp: { offset: 0, bytes: PERCOLAT_MAGIC.toString("base64") } },
-          ],
+          filters: [slabMagicMemcmpFilter()],
         });
       }
 
       // Filter to valid slabs
       const markets = accounts.filter(({ account }) => {
-        if (account.data.length < 8) return false;
-        return account.data.subarray(0, 8).equals(PERCOLAT_MAGIC);
+        return hasSlabMagic(account.data);
       });
 
       if (json) {

--- a/src/commands/push-oracle-price.ts
+++ b/src/commands/push-oracle-price.ts
@@ -43,6 +43,8 @@ export function registerPushOraclePrice(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/resolve-market.ts
+++ b/src/commands/resolve-market.ts
@@ -41,6 +41,8 @@ export function registerResolveMarket(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/set-oracle-authority.ts
+++ b/src/commands/set-oracle-authority.ts
@@ -46,6 +46,8 @@ export function registerSetOracleAuthority(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/slab-account.ts
+++ b/src/commands/slab-account.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseAccount, isAccountUsed, AccountKind } from "../solana/slab.js";
 import { validatePublicKey, validateIndex } from "../validation.js";
 
@@ -14,7 +14,7 @@ export function registerSlabAccount(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const idx = validateIndex(opts.idx, "--idx");

--- a/src/commands/slab-accounts.ts
+++ b/src/commands/slab-accounts.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseAllAccounts, AccountKind } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabAccounts(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-bitmap.ts
+++ b/src/commands/slab-bitmap.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseUsedIndices, parseEngine } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabBitmap(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-config.ts
+++ b/src/commands/slab-config.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseConfig, parseHeader } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabConfig(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-engine.ts
+++ b/src/commands/slab-engine.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseEngine } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabEngine(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-get.ts
+++ b/src/commands/slab-get.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseHeader, parseConfig } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabGet(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-header.ts
+++ b/src/commands/slab-header.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseHeader } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabHeader(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-nonce.ts
+++ b/src/commands/slab-nonce.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, readNonce } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabNonce(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/slab-params.ts
+++ b/src/commands/slab-params.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { getGlobalFlags } from "../cli.js";
 import { loadConfig } from "../config.js";
-import { createContext } from "../runtime/context.js";
+import { createReadOnlyContext } from "../runtime/context.js";
 import { fetchSlab, parseParams } from "../solana/slab.js";
 import { validatePublicKey } from "../validation.js";
 
@@ -13,7 +13,7 @@ export function registerSlabParams(program: Command): void {
     .action(async (opts, cmd) => {
       const flags = getGlobalFlags(cmd);
       const config = loadConfig(flags);
-      const ctx = createContext(config);
+      const ctx = createReadOnlyContext(config);
 
       const slabPk = validatePublicKey(opts.slab, "--slab");
       const data = await fetchSlab(ctx.connection, slabPk, ctx.programId);

--- a/src/commands/topup-insurance.ts
+++ b/src/commands/topup-insurance.ts
@@ -60,6 +60,8 @@ export function registerTopupInsurance(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/trade-cpi.ts
+++ b/src/commands/trade-cpi.ts
@@ -103,6 +103,8 @@ export function registerTradeCpi(program: Command): void {
         signers,
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/trade-nocpi.ts
+++ b/src/commands/trade-nocpi.ts
@@ -94,6 +94,8 @@ export function registerTradeNocpi(program: Command): void {
         signers,
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/update-admin.ts
+++ b/src/commands/update-admin.ts
@@ -48,6 +48,8 @@ export function registerUpdateAdmin(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/update-config.ts
+++ b/src/commands/update-config.ts
@@ -93,6 +93,8 @@ export function registerUpdateConfig(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       if (!flags.json) {

--- a/src/commands/withdraw-insurance.ts
+++ b/src/commands/withdraw-insurance.ts
@@ -55,6 +55,8 @@ export function registerWithdrawInsurance(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/commands/withdraw.ts
+++ b/src/commands/withdraw.ts
@@ -94,6 +94,8 @@ export function registerWithdraw(program: Command): void {
         signers: [ctx.payer],
         simulate: flags.simulate ?? false,
         commitment: ctx.commitment,
+        rpcUrl: config.rpcUrl,
+        allowMainnet: flags.yesMainnet ?? false,
       });
 
       console.log(formatResult(result, flags.json ?? false));

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,16 @@ const ConfigSchema = z.object({
 
 export type Config = z.infer<typeof ConfigSchema>;
 
+const FileConfigSchema = z
+  .object({
+    rpcUrl: z.string().url().optional(),
+    programId: z.string().optional(),
+    wallet: z.string().optional(),
+    walletPath: z.string().optional(),
+    commitment: CommitmentSchema.optional(),
+  })
+  .passthrough();
+
 export interface GlobalFlags {
   config?: string;
   rpc?: string;
@@ -22,6 +32,8 @@ export interface GlobalFlags {
   commitment?: Commitment;
   json?: boolean;
   simulate?: boolean;
+  send?: boolean;
+  yesMainnet?: boolean;
 }
 
 const DEFAULT_CONFIG_NAME = "percolator-cli.json";
@@ -31,13 +43,13 @@ const DEFAULT_CONFIG_NAME = "percolator-cli.json";
  */
 export function loadConfig(flags: GlobalFlags): Config {
   // Find config file
-  const configPath = flags.config ?? findConfig();
+  const configPath = flags.config ? expandPath(flags.config) : findConfig();
 
   let fileConfig: Partial<Config> = {};
   if (configPath && existsSync(configPath)) {
     try {
       const raw = readFileSync(configPath, "utf-8");
-      fileConfig = JSON.parse(raw);
+      fileConfig = normalizeFileConfig(JSON.parse(raw), configPath);
     } catch (e) {
       throw new Error(`Failed to parse config file ${configPath}: ${e}`);
     }
@@ -65,8 +77,29 @@ export function loadConfig(flags: GlobalFlags): Config {
  * Find config file in cwd.
  */
 function findConfig(): string | undefined {
-  const path = resolve(process.cwd(), DEFAULT_CONFIG_NAME);
-  return existsSync(path) ? path : undefined;
+  const cwdPath = resolve(process.cwd(), DEFAULT_CONFIG_NAME);
+  if (existsSync(cwdPath)) return cwdPath;
+
+  const home = process.env.HOME ?? process.env.USERPROFILE;
+  if (!home) return undefined;
+  const homePath = resolve(home, ".config", DEFAULT_CONFIG_NAME);
+  return existsSync(homePath) ? homePath : undefined;
+}
+
+function normalizeFileConfig(raw: unknown, configPath: string): Partial<Config> {
+  const result = FileConfigSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`);
+    throw new Error(`Invalid config file ${configPath}:\n${issues.join("\n")}`);
+  }
+
+  const parsed = result.data;
+  return {
+    rpcUrl: parsed.rpcUrl,
+    programId: parsed.programId,
+    wallet: parsed.wallet ?? parsed.walletPath,
+    commitment: parsed.commitment,
+  };
 }
 
 /**

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -3,27 +3,44 @@ import { Config } from "../config.js";
 import { loadKeypair } from "../solana/wallet.js";
 
 /**
- * Runtime context for all commands.
+ * Runtime context for read-only commands.
  */
-export interface Context {
+export interface ReadOnlyContext {
   connection: Connection;
-  payer: Keypair;
   programId: PublicKey;
   commitment: Commitment;
 }
 
 /**
- * Create runtime context from config.
+ * Runtime context for commands that need a signer.
  */
-export function createContext(config: Config): Context {
+export interface Context extends ReadOnlyContext {
+  payer: Keypair;
+}
+
+/**
+ * Create read-only runtime context from config without touching a wallet file.
+ */
+export function createReadOnlyContext(config: Config): ReadOnlyContext {
   const connection = new Connection(config.rpcUrl, config.commitment);
-  const payer = loadKeypair(config.wallet);
   const programId = new PublicKey(config.programId);
 
   return {
     connection,
-    payer,
     programId,
     commitment: config.commitment,
+  };
+}
+
+/**
+ * Create signer runtime context from config.
+ */
+export function createContext(config: Config): Context {
+  const readOnly = createReadOnlyContext(config);
+  const payer = loadKeypair(config.wallet);
+
+  return {
+    ...readOnly,
+    payer,
   };
 }

--- a/src/runtime/tx.ts
+++ b/src/runtime/tx.ts
@@ -44,6 +44,33 @@ export interface SimulateOrSendParams {
   simulate: boolean;
   commitment?: Commitment;
   computeUnitLimit?: number; // Custom compute unit limit (default: 200,000, max: 1,400,000)
+  rpcUrl?: string;
+  allowMainnet?: boolean;
+}
+
+export interface TxModeFlags {
+  simulate?: boolean;
+  send?: boolean;
+}
+
+/**
+ * Mainnet RPC detection for safety gates. This intentionally matches common
+ * endpoint naming, not a formal cluster registry.
+ */
+export function isMainnetRpc(rpcUrl: string): boolean {
+  const lower = rpcUrl.toLowerCase();
+  return lower.includes("mainnet") || lower.includes("api.mainnet-beta.solana.com");
+}
+
+/**
+ * Resolve transaction mode. The safe default is simulation; sending must be
+ * requested explicitly with --send.
+ */
+export function resolveTxMode(flags: TxModeFlags): { simulate: boolean } {
+  if (flags.simulate && flags.send) {
+    throw new Error("Choose either --simulate or --send, not both");
+  }
+  return { simulate: flags.send ? false : true };
 }
 
 /**
@@ -53,7 +80,25 @@ export interface SimulateOrSendParams {
 export async function simulateOrSend(
   params: SimulateOrSendParams
 ): Promise<TxResult> {
-  const { connection, ix, signers, simulate, commitment = "confirmed", computeUnitLimit } = params;
+  const {
+    connection,
+    ix,
+    signers,
+    simulate,
+    commitment = "confirmed",
+    computeUnitLimit,
+    rpcUrl,
+    allowMainnet = false,
+  } = params;
+
+  if (!simulate && rpcUrl && isMainnetRpc(rpcUrl) && !allowMainnet) {
+    return {
+      signature: "",
+      slot: 0,
+      err: "Refusing to send to a mainnet RPC without --yes-mainnet",
+      logs: [],
+    };
+  }
 
   const tx = new Transaction();
 

--- a/src/solana/slab.ts
+++ b/src/solana/slab.ts
@@ -1,4 +1,4 @@
-import { Connection, PublicKey } from "@solana/web3.js";
+import { Connection, PublicKey, type GetProgramAccountsFilter } from "@solana/web3.js";
 
 // =============================================================================
 // Constants — BPF layout (u128/i128 have 8-byte alignment, not 16-byte
@@ -24,7 +24,9 @@ import { Connection, PublicKey } from "@solana/web3.js";
 //                               b_rem + b_epoch_snap = 56 bytes for
 //                               B-index account-local bankruptcy state)
 // =============================================================================
-const MAGIC: bigint = 0x504552434f4c4154n; // "PERCOLAT"
+export const SLAB_MAGIC: bigint = 0x504552434f4c4154n; // "PERCOLAT"
+// The u64 magic is stored little-endian on chain, so the account bytes are "TALOCREP".
+export const SLAB_MAGIC_BYTES = [0x54, 0x41, 0x4c, 0x4f, 0x43, 0x52, 0x45, 0x50] as const;
 const HEADER_LEN = 136;
 const CONFIG_OFFSET = HEADER_LEN;
 const CONFIG_LEN = 384;
@@ -36,6 +38,21 @@ const FLAG_ORACLE_INITIALIZED = 1 << 3;
 
 export const SLAB_LEN = 1_755_520;
 export { HEADER_LEN, CONFIG_LEN };
+
+export function hasSlabMagic(data: Buffer | Uint8Array): boolean {
+  if (data.length < SLAB_MAGIC_BYTES.length) return false;
+  return SLAB_MAGIC_BYTES.every((byte, i) => data[i] === byte);
+}
+
+export function slabMagicMemcmpFilter(): GetProgramAccountsFilter {
+  return {
+    memcmp: {
+      offset: 0,
+      encoding: "base64",
+      bytes: Buffer.from(SLAB_MAGIC_BYTES).toString("base64"),
+    },
+  };
+}
 
 /**
  * Slab header (136 bytes, v12.20+ — close_authority removed).
@@ -142,8 +159,8 @@ export function parseHeader(data: Buffer): SlabHeader {
     throw new Error(`Slab data too short for header: ${data.length} < ${HEADER_LEN}`);
   }
   const magic = data.readBigUInt64LE(0);
-  if (magic !== MAGIC) {
-    throw new Error(`Invalid slab magic: expected ${MAGIC.toString(16)}, got ${magic.toString(16)}`);
+  if (magic !== SLAB_MAGIC) {
+    throw new Error(`Invalid slab magic: expected ${SLAB_MAGIC.toString(16)}, got ${magic.toString(16)}`);
   }
   return {
     magic,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "../src/config.js";
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+console.log("Testing config loading...\n");
+
+const oldHome = process.env.HOME;
+const oldCwd = process.cwd();
+const tmp = mkdtempSync(join(tmpdir(), "percolator-config-"));
+
+try {
+  const home = join(tmp, "home");
+  const cwd = join(tmp, "cwd");
+  mkdirSync(join(home, ".config"), { recursive: true });
+  mkdirSync(cwd, { recursive: true });
+  process.env.HOME = home;
+  process.chdir(cwd);
+
+  writeFileSync(
+    join(home, ".config", "percolator-cli.json"),
+    JSON.stringify({
+      rpcUrl: "https://api.devnet.solana.com",
+      programId: "2SSnp35m7FQ7cRLNKGdW5UzjYFF6RBUNq7d3m5mqNByp",
+      walletPath: "~/custom-devnet-wallet.json",
+      commitment: "finalized",
+    })
+  );
+
+  const config = loadConfig({});
+  assert(config.rpcUrl === "https://api.devnet.solana.com", "loads documented home config");
+  assert(config.wallet === "~/custom-devnet-wallet.json", "accepts documented walletPath alias");
+  assert(config.commitment === "finalized", "preserves commitment from home config");
+  console.log("✓ documented home config with walletPath alias");
+
+  const overridden = loadConfig({ wallet: "~/cli-wallet.json", rpc: "https://example.com" });
+  assert(overridden.wallet === "~/cli-wallet.json", "CLI wallet overrides file walletPath");
+  assert(overridden.rpcUrl === "https://example.com", "CLI RPC overrides file RPC");
+  console.log("✓ CLI overrides file config");
+} finally {
+  process.chdir(oldCwd);
+  if (oldHome === undefined) delete process.env.HOME;
+  else process.env.HOME = oldHome;
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log("\n✅ All config tests passed!");

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,0 +1,24 @@
+import { createReadOnlyContext } from "../src/runtime/context.js";
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+console.log("Testing runtime contexts...\n");
+
+{
+  const ctx = createReadOnlyContext({
+    rpcUrl: "https://api.devnet.solana.com",
+    programId: "2SSnp35m7FQ7cRLNKGdW5UzjYFF6RBUNq7d3m5mqNByp",
+    wallet: "/path/that/should/not/be/read.json",
+    commitment: "confirmed",
+  });
+
+  assert(ctx.programId.toBase58() === "2SSnp35m7FQ7cRLNKGdW5UzjYFF6RBUNq7d3m5mqNByp", "program ID parsed");
+  assert(ctx.commitment === "confirmed", "commitment preserved");
+  assert(!("payer" in ctx), "read-only context has no payer");
+
+  console.log("✓ createReadOnlyContext does not require a wallet file");
+}
+
+console.log("\n✅ All context tests passed!");

--- a/test/mainnet-bounty3-tick.test.ts
+++ b/test/mainnet-bounty3-tick.test.ts
@@ -1,0 +1,45 @@
+import { diff, type Snapshot } from "../scripts/mainnet-bounty3-tick.js";
+
+function snapshot(overrides: Partial<Snapshot> = {}): Snapshot {
+  return {
+    iso: "2026-05-13T00:00:00.000Z",
+    slot: 1_000,
+    marketSlot: 950n,
+    marketSlotLag: 50,
+    numUsed: 1,
+    vault: 1_000_000n,
+    cTot: 900_000n,
+    insurance: 100_000n,
+    spl: 1_000_000n,
+    lastOraclePrice: 100_000_000n,
+    sideModeLong: 0,
+    sideModeShort: 0,
+    rrCursor: 0n,
+    sweepGen: 0n,
+    priceMoveConsumed: 0n,
+    conservationOk: true,
+    accountingOk: true,
+    ...overrides,
+  };
+}
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+const SCALE = 1_000_000_000n;
+const pre = snapshot();
+const post = snapshot({ priceMoveConsumed: 401n * SCALE });
+
+const result = diff(pre, post);
+
+assert(
+  result.flags.includes("PRICE_MOVE_SAT(consumed=401bps)"),
+  "PRICE_MOVE_SAT fires when consumed price move exceeds threshold"
+);
+assert(
+  result.deltas.priceMoveConsumedBps === "401",
+  "price move consumed delta is reported in bps"
+);
+
+console.log("✓ mainnet bounty3 PRICE_MOVE_SAT alert");

--- a/test/slab-discovery.test.ts
+++ b/test/slab-discovery.test.ts
@@ -1,0 +1,41 @@
+import {
+  hasSlabMagic,
+  parseHeader,
+  slabMagicMemcmpFilter,
+  SLAB_MAGIC,
+  SLAB_MAGIC_BYTES,
+} from "../src/solana/slab.js";
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+console.log("Testing slab discovery filters...\n");
+
+const magicBytes = Buffer.from(SLAB_MAGIC_BYTES);
+const validSlab = Buffer.alloc(136);
+validSlab.writeBigUInt64LE(SLAB_MAGIC, 0);
+
+assert(magicBytes.toString("ascii") === "TALOCREP", "slab magic is little-endian account bytes");
+assert(hasSlabMagic(validSlab), "hasSlabMagic accepts LE parser bytes");
+
+const bigEndianBytes = Buffer.from("PERCOLAT", "ascii");
+assert(!hasSlabMagic(bigEndianBytes), "hasSlabMagic rejects BE ASCII bytes");
+
+let threw = false;
+try {
+  parseHeader(Buffer.concat([bigEndianBytes, Buffer.alloc(128)]));
+} catch {
+  threw = true;
+}
+assert(threw, "parseHeader rejects BE ASCII magic");
+
+const filter = slabMagicMemcmpFilter();
+assert("memcmp" in filter, "discovery filter is memcmp");
+assert(filter.memcmp.offset === 0, "memcmp starts at account byte zero");
+assert(filter.memcmp.encoding === "base64", "memcmp declares base64 encoding");
+assert(filter.memcmp.bytes === magicBytes.toString("base64"), "memcmp bytes use LE slab magic");
+assert(Buffer.from(filter.memcmp.bytes, "base64").equals(magicBytes), "memcmp base64 decodes to LE slab magic");
+
+console.log("✓ slab magic bytes and memcmp filter");
+console.log("\n✅ All slab discovery tests passed!");

--- a/test/slab.test.ts
+++ b/test/slab.test.ts
@@ -3,12 +3,13 @@ import {
   parseHeader,
   parseConfig,
   readNonce,
-  readLastThrUpdateSlot,
+  readMatCounter,
   parseAccount,
   parseEngine,
   parseParams,
   parseUsedIndices,
   isAccountUsed,
+  layoutForDataLength,
   AccountKind,
 } from "../src/solana/slab.js";
 
@@ -18,52 +19,63 @@ function assert(cond: boolean, msg: string): void {
 
 console.log("Testing slab parsing...\n");
 
+const MAGIC = 0x504552434f4c4154n;
+const HEADER_LEN = 136;
+const CONFIG_OFFSET = HEADER_LEN;
+const CONFIG_LEN = 384;
+const ENGINE_OFF = 520;
+const ENGINE_BITMAP_OFF = 1088;
+const ENGINE_PARAMS_OFF = 32;
+const PARAMS_MAX_ACCOUNTS_OFF = 24;
+const ACCOUNT_SIZE = 416;
+const MAX_ACCOUNTS = 64;
+
+const layout = layoutForDataLength(29176);
+
 // Create a mock slab buffer
 function createMockSlab(): Buffer {
-  const buf = Buffer.alloc(592);  // HEADER_LEN(72) + CONFIG_LEN(512) + 8 = 592 minimum
+  const buf = Buffer.alloc(HEADER_LEN + CONFIG_LEN);
 
-  // Header (72 bytes)
-  // magic: "PERCOLAT" = 0x504552434f4c4154
-  buf.writeBigUInt64LE(0x504552434f4c4154n, 0);
-  // version: 1
+  // Header (136 bytes)
+  buf.writeBigUInt64LE(MAGIC, 0);
   buf.writeUInt32LE(1, 8);
-  // bump: 255
   buf.writeUInt8(255, 12);
-  // padding: 3 bytes (skip)
-  // admin: 32 bytes (use zeros, which is valid as a pubkey)
+  buf.writeUInt8(0b1100, 13);
   const adminBytes = Buffer.alloc(32);
-  adminBytes[0] = 1; // Make it non-zero
+  adminBytes[0] = 1;
   adminBytes.copy(buf, 16);
-  // reserved: nonce at [48..56], lastThrUpdateSlot at [56..64], then 8 more bytes padding to 72
-  buf.writeBigUInt64LE(42n, 48); // nonce = 42
-  buf.writeBigUInt64LE(12345n, 56); // lastThrUpdateSlot = 12345
+  buf.writeBigUInt64LE(42n, 48); // nonce
+  buf.writeBigUInt64LE(12345n, 56); // matCounter
+  const insuranceAuthority = Buffer.alloc(32);
+  insuranceAuthority[0] = 0x44;
+  insuranceAuthority.copy(buf, 72);
+  const insuranceOperator = Buffer.alloc(32);
+  insuranceOperator[0] = 0x45;
+  insuranceOperator.copy(buf, 104);
 
-  // MarketConfig (starting at offset 72)
+  // MarketConfig (starting at offset 136)
   // Layout: collateral_mint(32) + vault_pubkey(32) + index_feed_id(32)
   //         + max_staleness_secs(8) + conf_filter_bps(2) + vault_authority_bump(1) + invert(1) + unit_scale(4)
 
-  // collateralMint: 32 bytes at offset 72
+  let off = CONFIG_OFFSET;
   const mintBytes = Buffer.alloc(32);
   mintBytes[0] = 2;
-  mintBytes.copy(buf, 72);
-  // vaultPubkey: 32 bytes at offset 104
+  mintBytes.copy(buf, off); off += 32;
   const vaultBytes = Buffer.alloc(32);
   vaultBytes[0] = 3;
-  vaultBytes.copy(buf, 104);
-  // index_feed_id: 32 bytes at offset 136
+  vaultBytes.copy(buf, off); off += 32;
   const feedIdBytes = Buffer.alloc(32);
   feedIdBytes[0] = 5;
-  feedIdBytes.copy(buf, 136);
-  // maxStalenessSecs: u64 at offset 168
-  buf.writeBigUInt64LE(100n, 168);
-  // confFilterBps: u16 at offset 176
-  buf.writeUInt16LE(50, 176);
-  // vaultAuthorityBump: u8 at offset 178
-  buf.writeUInt8(254, 178);
-  // invert: u8 at offset 179
-  buf.writeUInt8(1, 179);
-  // unitScale: u32 at offset 180
-  buf.writeUInt32LE(0, 180);
+  feedIdBytes.copy(buf, off); off += 32;
+  buf.writeBigUInt64LE(100n, off); off += 8;
+  buf.writeUInt16LE(50, off); off += 2;
+  buf.writeUInt8(254, off); off += 1;
+  buf.writeUInt8(1, off); off += 1;
+  buf.writeUInt32LE(0, off); off += 4;
+  buf.writeBigUInt64LE(77n, off); off += 8;
+  buf.writeBigUInt64LE(88n, off); off += 8;
+  buf.writeBigInt64LE(-99n, off); off += 8;
+  buf.writeBigInt64LE(-111n, off);
 
   return buf;
 }
@@ -73,12 +85,15 @@ function createMockSlab(): Buffer {
   const slab = createMockSlab();
   const header = parseHeader(slab);
 
-  assert(header.magic === 0x504552434f4c4154n, "header magic");
+  assert(header.magic === MAGIC, "header magic");
   assert(header.version === 1, "header version");
   assert(header.bump === 255, "header bump");
+  assert(header.flags === 0b1100, "header flags");
   assert(header.admin instanceof PublicKey, "header admin is PublicKey");
   assert(header.nonce === 42n, "header nonce");
-  assert(header.lastThrUpdateSlot === 12345n, "header lastThrUpdateSlot");
+  assert(header.matCounter === 12345n, "header matCounter");
+  assert(header.insuranceAuthority instanceof PublicKey, "header insuranceAuthority is PublicKey");
+  assert(header.insuranceOperator instanceof PublicKey, "header insuranceOperator is PublicKey");
 
   console.log("✓ parseHeader");
 }
@@ -96,6 +111,10 @@ function createMockSlab(): Buffer {
   assert(config.vaultAuthorityBump === 254, "config vaultAuthorityBump");
   assert(config.invert === 1, "config invert");
   assert(config.unitScale === 0, "config unitScale");
+  assert(config.fundingHorizonSlots === 77n, "config fundingHorizonSlots");
+  assert(config.fundingKBps === 88n, "config fundingKBps");
+  assert(config.fundingMaxPremiumBps === -99n, "config fundingMaxPremiumBps");
+  assert(config.fundingMaxE9PerSlot === -111n, "config fundingMaxE9PerSlot");
 
   console.log("✓ parseConfig");
 }
@@ -108,12 +127,12 @@ function createMockSlab(): Buffer {
   console.log("✓ readNonce");
 }
 
-// Test readLastThrUpdateSlot
+// Test readMatCounter
 {
   const slab = createMockSlab();
-  const slot = readLastThrUpdateSlot(slab);
-  assert(slot === 12345n, "readLastThrUpdateSlot");
-  console.log("✓ readLastThrUpdateSlot");
+  const counter = readMatCounter(slab);
+  assert(counter === 12345n, "readMatCounter");
+  console.log("✓ readMatCounter");
 }
 
 // Test error on invalid magic
@@ -157,21 +176,17 @@ console.log("\n✅ All basic slab tests passed!");
 
 console.log("\nTesting account parsing...\n");
 
-// Constants from slab.ts for testing (keep in sync with slab.ts)
-const ENGINE_OFF = 472;
-const ENGINE_ACCOUNTS_OFF = 9376;
-const ACCOUNT_SIZE = 352;
-const ENGINE_BITMAP_OFF = 664;
-
 // Account field offsets (SBF layout, 8-byte alignment for u128/i128)
-;
 const ACCT_CAPITAL_OFF = 0;
 const ACCT_KIND_OFF = 16;
 const ACCT_PNL_OFF = 24;
 const ACCT_POSITION_BASIS_Q_OFF = 56;
-const ACCT_MATCHER_PROGRAM_OFF = 128;
-const ACCT_MATCHER_CONTEXT_OFF = 160;
-const ACCT_OWNER_OFF = 192;
+const ACCT_LOSS_WEIGHT_OFF = 128;
+const ACCT_B_SNAP_OFF = 144;
+const ACCT_B_REM_OFF = 160;
+const ACCT_B_EPOCH_SNAP_OFF = 176;
+const ACCT_MATCHER_PROGRAM_OFF = 184;
+const ACCT_OWNER_OFF = 248;
 
 // Helper to write u128 as two u64s
 function writeU128LE(buf: Buffer, offset: number, value: bigint): void {
@@ -191,35 +206,43 @@ function writeI128LE(buf: Buffer, offset: number, value: bigint): void {
 
 // Create a full mock slab with accounts
 function createFullMockSlab(): Buffer {
-  // Need enough space for header + config + engine + bitmap + accounts
-  const minSize = ENGINE_OFF + ENGINE_ACCOUNTS_OFF + ACCOUNT_SIZE * 4;
-  const buf = Buffer.alloc(minSize);
+  const buf = Buffer.alloc(layout.slabLen);
 
-  // Header (72 bytes)
-  buf.writeBigUInt64LE(0x504552434f4c4154n, 0);  // magic
+  // Header (136 bytes)
+  buf.writeBigUInt64LE(MAGIC, 0);  // magic
   buf.writeUInt32LE(1, 8);  // version
   buf.writeUInt8(255, 12);  // bump
   const adminBytes = Buffer.alloc(32);
   adminBytes[0] = 1;
   adminBytes.copy(buf, 16);
   buf.writeBigUInt64LE(42n, 48);  // nonce
-  buf.writeBigUInt64LE(12345n, 56);  // lastThrUpdateSlot
+  buf.writeBigUInt64LE(12345n, 56);  // matCounter
 
-  // MarketConfig - simplified (starts at offset 72)
+  // MarketConfig - simplified (starts at offset 136)
   const mintBytes = Buffer.alloc(32);
   mintBytes[0] = 2;
-  mintBytes.copy(buf, 72);
+  mintBytes.copy(buf, CONFIG_OFFSET);
+
+  // RiskParams
+  const paramsBase = ENGINE_OFF + ENGINE_PARAMS_OFF;
+  buf.writeBigUInt64LE(BigInt(MAX_ACCOUNTS), paramsBase + PARAMS_MAX_ACCOUNTS_OFF);
 
   // Set bitmap - mark accounts 0 and 1 as used
   const bitmapOffset = ENGINE_OFF + ENGINE_BITMAP_OFF;
   buf.writeBigUInt64LE(3n, bitmapOffset);  // bits 0 and 1 set
+  buf.writeUInt16LE(2, ENGINE_OFF + layout.engineNumUsedOff);
+  buf.writeUInt16LE(7, ENGINE_OFF + layout.engineFreeHeadOff);
 
   // Create account at index 0 (LP)
-  const acc0Base = ENGINE_OFF + ENGINE_ACCOUNTS_OFF + 0 * ACCOUNT_SIZE;
+  const acc0Base = ENGINE_OFF + layout.engineAccountsOff + 0 * ACCOUNT_SIZE;
   writeU128LE(buf, acc0Base + ACCT_CAPITAL_OFF, 1000000000n);  // capital: 1 SOL
   buf.writeUInt8(1, acc0Base + ACCT_KIND_OFF);  // kind: LP (1)
   writeI128LE(buf, acc0Base + ACCT_PNL_OFF, 0n);  // pnl: 0
   writeI128LE(buf, acc0Base + ACCT_POSITION_BASIS_Q_OFF, 0n);  // position: 0
+  writeU128LE(buf, acc0Base + ACCT_LOSS_WEIGHT_OFF, 11n);
+  writeU128LE(buf, acc0Base + ACCT_B_SNAP_OFF, 12n);
+  writeU128LE(buf, acc0Base + ACCT_B_REM_OFF, 13n);
+  buf.writeBigUInt64LE(14n, acc0Base + ACCT_B_EPOCH_SNAP_OFF);
   // Set matcher_program (non-zero for LP)
   const matcherProg = Buffer.alloc(32);
   matcherProg[0] = 0xAA;
@@ -230,11 +253,15 @@ function createFullMockSlab(): Buffer {
   owner0.copy(buf, acc0Base + ACCT_OWNER_OFF);
 
   // Create account at index 1 (User)
-  const acc1Base = ENGINE_OFF + ENGINE_ACCOUNTS_OFF + 1 * ACCOUNT_SIZE;
+  const acc1Base = ENGINE_OFF + layout.engineAccountsOff + 1 * ACCOUNT_SIZE;
   writeU128LE(buf, acc1Base + ACCT_CAPITAL_OFF, 500000000n);  // capital: 0.5 SOL
   buf.writeUInt8(0, acc1Base + ACCT_KIND_OFF);  // kind: User (0)
   writeI128LE(buf, acc1Base + ACCT_PNL_OFF, -100000n);  // pnl: -0.0001 SOL
   writeI128LE(buf, acc1Base + ACCT_POSITION_BASIS_Q_OFF, 1000000n);  // position: 1M units
+  writeU128LE(buf, acc1Base + ACCT_LOSS_WEIGHT_OFF, 21n);
+  writeU128LE(buf, acc1Base + ACCT_B_SNAP_OFF, 22n);
+  writeU128LE(buf, acc1Base + ACCT_B_REM_OFF, 23n);
+  buf.writeBigUInt64LE(24n, acc1Base + ACCT_B_EPOCH_SNAP_OFF);
   // matcher_program stays zero (User accounts don't have matchers)
   // Set owner
   const owner1 = Buffer.alloc(32);
@@ -268,9 +295,26 @@ function createFullMockSlab(): Buffer {
 
   assert(acc1.positionBasisQ === 1000000n, "account position basis q");
   assert(acc1.pnl === -100000n, "account pnl (negative)");
+  assert(acc1.lossWeight === 21n, "account lossWeight");
+  assert(acc1.bSnap === 22n, "account bSnap");
+  assert(acc1.bRem === 23n, "account bRem");
+  assert(acc1.bEpochSnap === 24n, "account bEpochSnap");
   assert(acc1.owner instanceof PublicKey, "account owner is PublicKey");
 
   console.log("✓ parseAccount fields (position, pnl, owner)");
+}
+
+// Test RiskParams and RiskEngine layout-derived fields
+{
+  const slab = createFullMockSlab();
+  const params = parseParams(slab);
+  const engine = parseEngine(slab);
+
+  assert(params.maxAccounts === BigInt(MAX_ACCOUNTS), "params maxAccounts");
+  assert(engine.numUsedAccounts === 2, "engine numUsedAccounts");
+  assert(engine.freeHead === 7, "engine freeHead");
+
+  console.log("✓ parseParams and parseEngine layout fields");
 }
 
 // Test bitmap parsing

--- a/test/tx.test.ts
+++ b/test/tx.test.ts
@@ -1,0 +1,42 @@
+import {
+  isMainnetRpc,
+  resolveTxMode,
+} from "../src/runtime/tx.js";
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+function assertThrows(fn: () => void, expectedMsg: string, testName: string): void {
+  try {
+    fn();
+    throw new Error(`FAIL: ${testName} - expected to throw`);
+  } catch (e) {
+    if (e instanceof Error && e.message.includes(expectedMsg)) return;
+    throw new Error(`FAIL: ${testName} - unexpected error: ${e}`);
+  }
+}
+
+console.log("Testing transaction safety helpers...\n");
+
+{
+  assert(isMainnetRpc("https://api.mainnet-beta.solana.com"), "detects public mainnet RPC");
+  assert(isMainnetRpc("https://mainnet.helius-rpc.com/?api-key=redacted"), "detects Helius mainnet RPC");
+  assert(!isMainnetRpc("https://api.devnet.solana.com"), "does not classify devnet as mainnet");
+  assert(!isMainnetRpc("http://127.0.0.1:8899"), "does not classify localnet as mainnet");
+  console.log("✓ isMainnetRpc");
+}
+
+{
+  assert(resolveTxMode({ simulate: false, send: false }).simulate === true, "defaults to simulation");
+  assert(resolveTxMode({ simulate: true, send: false }).simulate === true, "--simulate stays simulation");
+  assert(resolveTxMode({ simulate: false, send: true }).simulate === false, "--send opts into send");
+  assertThrows(
+    () => resolveTxMode({ simulate: true, send: true }),
+    "Choose either --simulate or --send",
+    "rejects conflicting tx mode flags"
+  );
+  console.log("✓ resolveTxMode");
+}
+
+console.log("\n✅ All transaction helper tests passed!");


### PR DESCRIPTION
## Summary
- split signer-free inspection commands onto a read-only runtime context so slab/list/best-price reads do not load wallet keypairs
- make transaction commands simulate by default, require explicit `--send`, and refuse obvious mainnet sends without `--yes-mainnet`
- repair slab discovery/layout drift by sharing `SLAB_LEN`, little-endian slab magic bytes, and explicit base64 memcmp filters
- fix monitor/script drift for the current engine price-move field and replace copied slab-size constants with exported `SLAB_LEN`
- refresh README/config examples and add offline regressions for config, context, tx mode, slab discovery, and Bounty 3 alerting

## Why
This CLI is frequently used for high-risk Solana operations. A few defaults and duplicated constants made it too easy for agents/operators to load keypairs for read-only work, submit transactions accidentally, or miss real slabs because of stale discovery bytes/sizes.

## Notes
- `--send` is now required for transaction submission; `--simulate` remains accepted and is the default.
- Simulation still signs locally with the configured wallet because Solana transaction simulation needs a signed transaction; read-only commands avoid wallet loading entirely.
- The mainnet gate is conservative string-based detection for common mainnet RPC URLs, not a full cluster registry.

## Test Plan
- `NO_DNA=1 corepack pnpm test`
- `NO_DNA=1 corepack pnpm build`
- `NO_DNA=1 corepack pnpm exec tsc --noEmit`
- `git diff --check`
