### PR TITLE
fix: scale estimateCu by oracleLegCount for Bounty 4 3-leg oracle

### DIFF
--- a/scripts/mainnet-bounty4-tick.ts
+++ b/scripts/mainnet-bounty4-tick.ts
@@ -138,12 +138,12 @@ async function main() {
   const PRIORITY_FLOOR = 1;
   const PRIORITY_CEIL = 100_000;
 
-  function estimateCu(n: number, marketMode: number, oiAny: boolean, lag: number): number {
+  function estimateCu(n: number, marketMode: number, oiAny: boolean, lag: number, oracleLegCount: number = 1): number {
     if (n < 1) n = 1;
     const BASE = 60_000;
     let perCrankCost: number[];
     if (marketMode === 1) perCrankCost = Array(n).fill(15_000);
-    else if (!oiAny || lag <= 10) perCrankCost = Array(n).fill(95_000);
+    else if (!oiAny || lag <= 10) perCrankCost = Array(n).fill(95_000 + 60_000 * (oracleLegCount - 1));
     else {
       perCrankCost = [];
       for (let k = 0; k < n; k++) {
@@ -220,7 +220,7 @@ async function main() {
 
     const segmentsNeeded = Math.max(1, Math.ceil(lagNow / 10));
     const n = Math.max(1, Math.min(nMax, segmentsNeeded));
-    const cuLimit = estimateCu(n, marketMode, oiAny, lagNow);
+    const cuLimit = estimateCu(n, marketMode, oiAny, lagNow, oracleLegs.length);
 
     let sig: string | null = null;
     let err: string | null = null;


### PR DESCRIPTION
## Fix: scale estimateCu by oracleLegCount for Bounty 4 3-leg oracle

### Problem
Bounty 4's estimateCu was a verbatim copy from Bounty 3, which only has a single-leg pyth_pull oracle. Bounty 4 uses pyth_pull_composite_3leg (STOXX50_EUR x EUR_USD / SOL_USD, 3 legs), requiring ~3x the oracle parsing compute.

Result: 100% KeeperCrank failure rate -- 6,977+ failed txns across 5h 40min+, slot lag growing past maxStalenessSecs: 600.

### Fix
- Added oracleLegCount param to estimateCu(), defaulting to 1 for backward compat
- In the !oiAny || lag <= 10 branch, scale per-crank CU by (oracleLegCount - 1) x 60,000
- Single-leg (Bounty 3): 95k/crank (unchanged)
- 3-leg composite (Bounty 4): 95k + 120k = 215k/crank

Fixes #70