### PR TITLE
fix(cli): correct Bounty 5 manifest permissionless resolve slots

### DIFF
--- a/mainnet-bounty5-v16-market.json
+++ b/mainnet-bounty5-v16-market.json
@@ -11,7 +11,7 @@
   "leverage": 20,
   "maintenanceMarginBps": 500,
   "forceCloseDelaySlots": 216000,
-  "permissionlessResolveStaleSlots": 100,
+  "permissionlessResolveStaleSlots": 6480000,
   "solUsdPriceE6": "86206344",
   "fees": {
     "newAccount": {
@@ -61,7 +61,8 @@
       "oracleAccounts": [
         "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"
       ],
-      "validation": "FAIL"
+      "validation": "FAIL",
+      "validationNote": "Deploy-time TradeNoCpi open/close probe failed on 2026-05-25; oracle accounts and feed IDs are still authoritative for ticks."
     },
     {
       "asset": "m1",
@@ -80,7 +81,8 @@
         "Fu76ChamBDjE8UuGLV6GP2AcPPSU6gjhkNhAyuoPm7ny",
         "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"
       ],
-      "validation": "FAIL"
+      "validation": "FAIL",
+      "validationNote": "Deploy-time TradeNoCpi open/close probe failed on 2026-05-25; oracle accounts and feed IDs are still authoritative for ticks."
     },
     {
       "asset": "m2",
@@ -97,7 +99,8 @@
         "4cSM2e6rvbGQUFiJbqytoVMi5GgghSMr8LwVrT9VPSPo",
         "7UVimffxr9ow1uXYxsr4LHAcV58mLzhmwaeKvJ1pjLiE"
       ],
-      "validation": "FAIL"
+      "validation": "FAIL",
+      "validationNote": "Deploy-time TradeNoCpi open/close probe failed on 2026-05-25; oracle accounts and feed IDs are still authoritative for ticks."
     }
   ],
   "keeperPortfolio": "38QSu57zCu2PKwJtzjiK3cK7qRnTWriXhx6Y2bKDb13H",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
+    "test": "tsx scripts/verify-bounty5-manifest.ts",
     "smoke": "tsx scripts/smoke-v16-bounty5.ts"
   },
   "dependencies": {

--- a/scripts/deploy-bounty5-v16.ts
+++ b/scripts/deploy-bounty5-v16.ts
@@ -50,6 +50,11 @@ import {
   PORTFOLIO_STATE_OFF, PA,
   ORACLE_LEG_FLAG_DIVIDE_LEG2, ORACLE_LEG_FLAG_DIVIDE_LEG3, OracleProvider,
 } from "../src/v16/index.js";
+import {
+  BOUNTY5_FORCE_CLOSE_DELAY_SLOTS,
+  BOUNTY5_FEE_REDIRECT_TO_MARKET_0_BPS,
+  BOUNTY5_PERM_RESOLVE_STALE_SLOTS,
+} from "../src/v16/bounty5-manifest-constants.js";
 
 // ============================================================================
 // Config / environment
@@ -127,12 +132,11 @@ const ORACLE_DEFAULTS = {
 };
 
 const SLOTS_PER_DAY = 216_000n;            // ~0.4 s/slot
-const FORCE_CLOSE_DELAY = 216_000n;        // ~24h auto-wind-down
-const PERM_RESOLVE_STALE = 6_480_000n;      // ~30d grace (MAX) — at 100 the market hard-freezes
-                                            // (0x1b OracleStale) after just ~40s un-cranked. The
-                                            // keeper keeps it fresh; this is the keeper-downtime cushion.
+const FORCE_CLOSE_DELAY = BigInt(BOUNTY5_FORCE_CLOSE_DELAY_SLOTS);
+const PERM_RESOLVE_STALE = BigInt(BOUNTY5_PERM_RESOLVE_STALE_SLOTS);
+// ~30d grace — must not use legacy v12.21 cap of 100 slots (~40s hard-freeze).
 const INSURANCE_PER_MARKET = 500_000_000n; // 0.5 SOL per domain (1.5 SOL total)
-const FEE_REDIRECT_TO_M0_BPS = 2000;       // 20% of non-zero-market trade fees + backing yield → market 0
+const FEE_REDIRECT_TO_M0_BPS = BOUNTY5_FEE_REDIRECT_TO_MARKET_0_BPS;
 const TRADE_SIZE = 1_000_000n;   // = POS_SCALE (1 unit), matching the litesvm reference test
 const VALIDATE_DEPOSIT = 300_000_000n;
 
@@ -635,23 +639,40 @@ async function main() {
       market: `m${m.assetIndex}`, domain: m.assetIndex * 2,
       lamports: INSURANCE_PER_MARKET.toString(), sol: Number(INSURANCE_PER_MARKET) / 1e9,
     })),
-    markets: markets.map((m) => ({
-      asset: `m${m.assetIndex}`,
-      label: m.label,
-      assetIndex: m.assetIndex,
-      invert: m.invert,
-      oracleLegCount: m.oracleLegCount,
-      oracleLegFlags: `0x${m.oracleLegFlags.toString(16)}`,
-      legFeedIds: m.legFeeds.slice(0, m.oracleLegCount),
-      oracleAccounts: m.accounts.map((a) => a.toBase58()),
-      validation: validation[`m${m.assetIndex}`] ?? "UNKNOWN",
-    })),
+    markets: markets.map((m) => {
+      const status = validation[`m${m.assetIndex}`] ?? "UNKNOWN";
+      return {
+        asset: `m${m.assetIndex}`,
+        label: m.label,
+        assetIndex: m.assetIndex,
+        invert: m.invert,
+        oracleLegCount: m.oracleLegCount,
+        oracleLegFlags: `0x${m.oracleLegFlags.toString(16)}`,
+        legFeedIds: m.legFeeds.slice(0, m.oracleLegCount),
+        oracleAccounts: m.accounts.map((a) => a.toBase58()),
+        validation: status,
+        ...(status === "FAIL"
+          ? {
+              validationNote:
+                "Deploy-time TradeNoCpi open/close probe failed; oracle accounts and feed IDs are still authoritative for ticks.",
+            }
+          : {}),
+      };
+    }),
   };
 
   const manifestPath = NETWORK === "mainnet"
     ? `${HOME}/percolator-cli/mainnet-bounty5-v16-market.json`
     : `${HOME}/percolator-cli/bounty5-v16-devnet.json`;
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  const written = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+    permissionlessResolveStaleSlots: number;
+  };
+  if (written.permissionlessResolveStaleSlots !== Number(PERM_RESOLVE_STALE)) {
+    throw new Error(
+      `manifest permissionlessResolveStaleSlots=${written.permissionlessResolveStaleSlots} !== deploy ${PERM_RESOLVE_STALE}`,
+    );
+  }
 
   console.log("\n=================================");
   console.log(`PASS: ${passed}  FAIL: ${failed}`);

--- a/scripts/verify-bounty5-manifest.ts
+++ b/scripts/verify-bounty5-manifest.ts
@@ -1,0 +1,124 @@
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  BOUNTY5_FORCE_CLOSE_DELAY_SLOTS,
+  BOUNTY5_FEE_REDIRECT_TO_MARKET_0_BPS,
+  BOUNTY5_MAINNET_MARKET,
+  BOUNTY5_MAINNET_PROGRAM,
+  BOUNTY5_PERM_RESOLVE_STALE_SLOTS,
+  LEGACY_MAX_ACCRUAL_PERM_RESOLVE_CAP,
+} from "../src/v16/bounty5-manifest-constants.js";
+import { parseWrapperConfig } from "../src/v16/parsers.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+type MarketEntry = {
+  asset: string;
+  validation: string;
+  validationNote?: string;
+  oracleLegCount: number;
+  legFeedIds: string[];
+  oracleAccounts: string[];
+};
+
+type Manifest = {
+  network: string;
+  programId: string;
+  market: string;
+  permissionlessResolveStaleSlots: number;
+  forceCloseDelaySlots: number;
+  fees: { feeRedirectToMarket0Bps: number };
+  markets: MarketEntry[];
+};
+
+function loadManifest(name: string): Manifest {
+  const p = path.join(ROOT, name);
+  return JSON.parse(fs.readFileSync(p, "utf8")) as Manifest;
+}
+
+function checkManifestFile(file: string, expectNetwork: string): void {
+  const m = loadManifest(file);
+  assert(m.network === expectNetwork, `${file}: network`);
+  assert(
+    m.permissionlessResolveStaleSlots === BOUNTY5_PERM_RESOLVE_STALE_SLOTS,
+    `${file}: permissionlessResolveStaleSlots must be ${BOUNTY5_PERM_RESOLVE_STALE_SLOTS} (got ${m.permissionlessResolveStaleSlots})`,
+  );
+  assert(
+    m.permissionlessResolveStaleSlots !== LEGACY_MAX_ACCRUAL_PERM_RESOLVE_CAP,
+    `${file}: must not use legacy v12.21 cap of ${LEGACY_MAX_ACCRUAL_PERM_RESOLVE_CAP} slots`,
+  );
+  assert(
+    m.forceCloseDelaySlots === BOUNTY5_FORCE_CLOSE_DELAY_SLOTS,
+    `${file}: forceCloseDelaySlots`,
+  );
+  assert(
+    m.fees.feeRedirectToMarket0Bps === BOUNTY5_FEE_REDIRECT_TO_MARKET_0_BPS,
+    `${file}: feeRedirectToMarket0Bps`,
+  );
+  for (const entry of m.markets) {
+    assert(
+      entry.legFeedIds.length === entry.oracleLegCount,
+      `${file} ${entry.asset}: legFeedIds length`,
+    );
+    assert(
+      entry.oracleAccounts.length === entry.oracleLegCount,
+      `${file} ${entry.asset}: oracleAccounts length`,
+    );
+  }
+}
+
+async function verifyOnChain(): Promise<void> {
+  const rpc = process.env.RPC_URL ?? "https://api.mainnet-beta.solana.com";
+  const conn = new Connection(rpc, "confirmed");
+  const info = await conn.getAccountInfo(new PublicKey(BOUNTY5_MAINNET_MARKET), "confirmed");
+  assert(!!info?.data, "mainnet market account missing");
+  const cfg = parseWrapperConfig(Buffer.from(info!.data));
+  assert(
+    cfg.permissionlessResolveStaleSlots === BigInt(BOUNTY5_PERM_RESOLVE_STALE_SLOTS),
+    `on-chain permissionlessResolveStaleSlots: got ${cfg.permissionlessResolveStaleSlots}, want ${BOUNTY5_PERM_RESOLVE_STALE_SLOTS}`,
+  );
+  assert(
+    cfg.forceCloseDelaySlots === BigInt(BOUNTY5_FORCE_CLOSE_DELAY_SLOTS),
+    "on-chain forceCloseDelaySlots",
+  );
+  console.log("on-chain wrapper config matches manifest constants");
+}
+
+async function main(): Promise<void> {
+  console.log("verify-bounty5-manifest\n");
+  checkManifestFile("mainnet-bounty5-v16-market.json", "mainnet");
+  console.log("OK mainnet-bounty5-v16-market.json");
+  checkManifestFile("bounty5-v16-devnet.json", "devnet");
+  console.log("OK bounty5-v16-devnet.json");
+  const mainnet = loadManifest("mainnet-bounty5-v16-market.json");
+  assert(mainnet.programId === BOUNTY5_MAINNET_PROGRAM, "mainnet programId");
+  assert(mainnet.market === BOUNTY5_MAINNET_MARKET, "mainnet market");
+  const failed = mainnet.markets.filter((m) => m.validation === "FAIL");
+  if (failed.length > 0) {
+    for (const m of failed) {
+      assert(
+        typeof m.validationNote === "string" && m.validationNote.length > 20,
+        `mainnet ${m.asset}: FAIL must include validationNote`,
+      );
+    }
+    console.log(`OK mainnet FAIL markets documented (${failed.length})`);
+  }
+  if (process.env.VERIFY_CHAIN === "1") {
+    await verifyOnChain();
+  } else {
+    console.log("skip on-chain (set VERIFY_CHAIN=1 to verify mainnet RPC)");
+  }
+  console.log("\nAll bounty5 manifest checks passed.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/v16/bounty5-manifest-constants.ts
+++ b/src/v16/bounty5-manifest-constants.ts
@@ -1,0 +1,9 @@
+// Bounty 5 v16 deploy parameters (must match deploy-bounty5-v16.ts and README).
+export const BOUNTY5_PERM_RESOLVE_STALE_SLOTS = 6_480_000;
+export const BOUNTY5_FORCE_CLOSE_DELAY_SLOTS = 216_000;
+export const BOUNTY5_FEE_REDIRECT_TO_MARKET_0_BPS = 2_000;
+export const BOUNTY5_MAINNET_MARKET =
+  "8oYjDr2Rt6BCuBvwaUGx7gLnzQbkuARTtrQr7DijAHn7";
+export const BOUNTY5_MAINNET_PROGRAM =
+  "4m3ipBQDYX6JQ9YSmUXDjESDHMtGWtiXforkWr9Qoxdi";
+export const LEGACY_MAX_ACCRUAL_PERM_RESOLVE_CAP = 100;


### PR DESCRIPTION
The mainnet manifest had permissionlessResolveStaleSlots=100 (legacy v12.21 devnet cap) while deploy, README, devnet manifest, and on-chain config use 6_480_000 (~30d).

Add shared constants, verify script (npm test), deploy post-write guard, and validationNote for deploy-time FAIL trade probes.